### PR TITLE
Add rel="me" to social links and scroll-margin to anchored sections

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -21,7 +21,7 @@ const currentYear = new Date().getFullYear();
             <a
               href={link.url}
               target="_blank"
-              rel="noopener noreferrer"
+              rel="me noopener noreferrer"
               aria-label={link.name}
               class="text-cream/50 hover:text-sage-light transition-colors duration-200"
             >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,6 +15,11 @@
     scroll-behavior: smooth;
   }
 
+  /* Offset anchored sections so the fixed header doesn't cover the heading */
+  section[id] {
+    scroll-margin-top: 5rem;
+  }
+
   body {
     @apply font-sans text-ink dark:text-cream bg-cream dark:bg-ink-dark transition-colors duration-300;
     -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Summary
- Adds `rel="me"` to each social profile link in the footer to enable [RelMeAuth](https://indieweb.org/RelMeAuth) for IndieAuth web sign-in. The footer renders all four profiles (GitHub, LinkedIn, CodePen, Twitter) from `personalInfo.socialLinks`, so a single change in `Footer.astro` covers them all.
- Adds `scroll-margin-top: 5rem` to every `<section id="...">` so anchor navigation lands just below the fixed header instead of underneath it. Pairs with the existing `scroll-behavior: smooth` to give in-page navigation a polished feel.

## RelMeAuth notes
For verification to succeed, each social profile must also link back to `https://www.okeefesarah.com`:
- **GitHub** — set the website field on your profile.
- **LinkedIn** — add the site under Contact info → Website.
- **CodePen** — set the website field on your profile.
- **Twitter/X** — Twitter typically strips/nofollows external links, so it generally won't verify via RelMeAuth. Many people drop Twitter from their `rel="me"` set or rely on a separate IndieAuth method.

After deploy, paste the home page URL into [indielogin.com](https://indielogin.com) to confirm which profiles successfully verify.

## Test plan
- [ ] Run `npm run dev` and inspect a social link in the footer — confirm `rel="me noopener noreferrer"` is in the rendered HTML.
- [ ] Click a nav link (Projects, Writing, Contact) and confirm the section heading lands below the fixed header rather than under it.
- [ ] Confirm smooth scrolling still animates (and falls back to instant if the OS has reduce-motion enabled).
- [ ] After deploy: test with [indielogin.com](https://indielogin.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)