### PR TITLE
Add Prettier with single-quote preference + Astro plugin

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.astro/
+legacy/
+package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "singleQuote": true,
+  "plugins": ["prettier-plugin-astro"],
+  "overrides": [
+    {
+      "files": "*.astro",
+      "options": {
+        "parser": "astro"
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,10 @@
         "astro": "^6.1.6",
         "autoprefixer": "^10.4.20",
         "tailwindcss": "^3.4.17"
+      },
+      "devDependencies": {
+        "prettier": "^3.8.3",
+        "prettier-plugin-astro": "^0.14.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4425,6 +4429,44 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-astro": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
+      "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.9.1",
+        "prettier": "^3.0.0",
+        "sass-formatter": "^0.7.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-astro/node_modules/@astrojs/compiler": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -4828,6 +4870,23 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sass-formatter": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
+      "integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "suf-log": "^2.5.3"
+      }
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -4993,6 +5052,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "s.color": "0.0.15"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {

--- a/package.json
+++ b/package.json
@@ -7,14 +7,20 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
-    "astro": "^6.1.6",
     "@tailwindcss/typography": "^0.5.15",
+    "astro": "^6.1.6",
     "autoprefixer": "^10.4.20",
     "tailwindcss": "^3.4.17"
   },
   "author": "Sarah O'Keefe",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "prettier": "^3.8.3",
+    "prettier-plugin-astro": "^0.14.1"
+  }
 }


### PR DESCRIPTION
## Summary

Sets up [Prettier 3](https://prettier.io) with single-quote preference and adds [`prettier-plugin-astro`](https://github.com/withastro/prettier-plugin-astro) so `.astro` files get formatted alongside the rest of the codebase.

### Files

- `.prettierrc.json` — `singleQuote: true` + Astro plugin (with explicit parser override for `*.astro`)
- `.prettierignore` — excludes `node_modules/`, `dist/`, `.astro/`, `legacy/`, and `package-lock.json`
- `package.json` — adds `format` and `format:check` scripts; adds `prettier` and `prettier-plugin-astro` to `devDependencies`

### How apostrophes are handled

Prettier doesn't *escape* apostrophes (`\'`) — it auto-flips strings containing an apostrophe to double quotes:

```ts
// stays single-quoted
firstName: 'Sarah',

// auto-flips to double quotes because of the apostrophe
lastName: "O'Keefe",
```

This matches the convention you've already been using in your recent edits.

## What this PR does NOT do

I deliberately didn't run `prettier --write .` here. `prettier --check .` reports 20 files that would be reformatted (mostly `.astro` files). Applying those changes now would create merge conflicts with the open PR #36 (which touches several of the same files).

**Suggested follow-up**: after #36 lands, open a separate one-commit PR running `npm run format` so the resulting formatting changes are isolated and easy to review/blame-ignore.

## Test plan
- [ ] `npm install` succeeds locally
- [ ] `npm run format:check` runs (will report files needing formatting — that's expected for now)
- [ ] No effect on `npm run build` or `npm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)