### PR TITLE
Add F1 lights-out reaction-time easter egg

### DIFF
--- a/docs/superpowers/plans/2026-05-02-f1-lights-out-easter-egg.md
+++ b/docs/superpowers/plans/2026-05-02-f1-lights-out-easter-egg.md
@@ -1,0 +1,1550 @@
+# F1 Lights-Out Easter Egg Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a hidden F1 lights-out reaction-time game triggered by a centered checkered-flag glyph in the site footer, presented as a full-screen 8-bit pixel takeover.
+
+**Architecture:** A single overlay component (`LightsOut.astro`) is mounted globally in `BaseLayout.astro`. Its imperative logic lives in vanilla TypeScript modules colocated with the component. The footer dispatches a `lights-out:open` custom event on `window` that the overlay listens for. Pure logic (state machine, localStorage helpers) is unit-tested with vitest; DOM/animation behavior is verified manually in the browser.
+
+**Tech Stack:** Astro 6 (static), Tailwind CSS 3, vanilla TypeScript, Web Audio API, vitest (added by this plan), Press Start 2P from Google Fonts.
+
+**Spec:** [docs/superpowers/specs/2026-05-02-f1-lights-out-easter-egg-design.md](../specs/2026-05-02-f1-lights-out-easter-egg-design.md)
+
+---
+
+## File structure
+
+**New files:**
+
+- `src/components/lights-out/LightsOut.astro` — overlay markup + thin script that boots the controller
+- `src/components/lights-out/state.ts` — pure state-machine reducer (testable)
+- `src/components/lights-out/storage.ts` — defensive localStorage helpers (testable)
+- `src/components/lights-out/sound.ts` — Web Audio API tone generator
+- `src/components/lights-out/controller.ts` — DOM wiring, animation, focus trap, lifecycle
+- `src/components/lights-out/__tests__/state.test.ts` — vitest tests for the state machine
+- `src/components/lights-out/__tests__/storage.test.ts` — vitest tests for storage helpers
+- `vitest.config.ts` — vitest configuration
+
+**Modified files:**
+
+- `src/components/layout/Footer.astro` — add the centered `🏁` trigger button; restructure bottom bar to a 3-element layout
+- `src/components/layout/BaseLayout.astro` — mount `<LightsOut />` once and add the `Press Start 2P` Google Fonts preconnect/stylesheet
+- `package.json` — add `vitest` and `@vitest/ui` (optional) as devDependencies; add `test` and `test:watch` scripts
+
+**Why this layout:** Logic that's worth testing (state machine, storage) is isolated in pure modules. DOM-bound code (animation, focus, audio) is in `controller.ts` — kept in one file so the orchestration is easy to follow. The component owns markup/styles only.
+
+---
+
+## Task 1: Add vitest test setup
+
+**Files:**
+
+- Modify: `package.json`
+- Create: `vitest.config.ts`
+
+- [ ] **Step 1: Add vitest as a dev dependency**
+
+Run:
+
+```bash
+npm install --save-dev vitest@^2.1.0 jsdom@^25.0.0
+```
+
+Expected: `package.json` updated, `package-lock.json` updated, `node_modules/vitest` exists.
+
+- [ ] **Step 2: Add `test` scripts to package.json**
+
+Edit `package.json` `"scripts"` block to add:
+
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+So the full scripts block becomes:
+
+```json
+"scripts": {
+  "dev": "astro dev",
+  "start": "astro dev",
+  "build": "astro build",
+  "preview": "astro preview",
+  "astro": "astro",
+  "format": "prettier --write .",
+  "format:check": "prettier --check .",
+  "test": "vitest run",
+  "test:watch": "vitest"
+}
+```
+
+- [ ] **Step 3: Create `vitest.config.ts`**
+
+Create `vitest.config.ts`:
+
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/__tests__/**/*.test.ts'],
+    globals: false,
+  },
+});
+```
+
+- [ ] **Step 4: Verify vitest runs (no tests yet, so it should report "no tests found")**
+
+Run: `npm test`
+
+Expected: vitest starts, says something like "No test files found" with exit code 1, OR exits 0 with a "no tests" notice depending on version. Either is acceptable here — what matters is that the binary runs and the config loads without error.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json vitest.config.ts
+git commit -m "Add vitest for unit-testing the lights-out logic"
+```
+
+---
+
+## Task 2: State machine module (TDD)
+
+**Files:**
+
+- Create: `src/components/lights-out/state.ts`
+- Create: `src/components/lights-out/__tests__/state.test.ts`
+
+The state machine is a pure reducer: `(context, event) → context`. The controller will own all timers and DOM; this module just describes valid transitions and computes derived values like `reactionMs`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/components/lights-out/__tests__/state.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { initialContext, reduce, type Context } from '../state';
+
+describe('lights-out state machine', () => {
+  const baseCtx: Context = initialContext({ bestMs: null });
+
+  it('starts in idle', () => {
+    expect(baseCtx.state).toBe('idle');
+  });
+
+  it('idle + INPUT transitions to arming', () => {
+    const next = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    expect(next.state).toBe('arming');
+  });
+
+  it('arming + LIGHTS_ARMED transitions to holding', () => {
+    const armed = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    const holding = reduce(armed, { type: 'LIGHTS_ARMED' });
+    expect(holding.state).toBe('holding');
+  });
+
+  it('arming + INPUT transitions to jumpStart', () => {
+    const armed = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    const jumped = reduce(armed, { type: 'INPUT', timestamp: 100 });
+    expect(jumped.state).toBe('jumpStart');
+  });
+
+  it('holding + INPUT transitions to jumpStart', () => {
+    let ctx = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 200 });
+    expect(ctx.state).toBe('jumpStart');
+  });
+
+  it('holding + LIGHTS_OUT transitions to live and stores liveStartTime', () => {
+    let ctx = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 1234 });
+    expect(ctx.state).toBe('live');
+    expect(ctx.liveStartTime).toBe(1234);
+  });
+
+  it('live + INPUT transitions to result and computes reactionMs', () => {
+    let ctx = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 1000 });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 1287 });
+    expect(ctx.state).toBe('result');
+    expect(ctx.reactionMs).toBe(287);
+  });
+
+  it('result with new best updates bestMs and flags isNewBest', () => {
+    let ctx = reduce(initialContext({ bestMs: 500 }), { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
+    expect(ctx.reactionMs).toBe(287);
+    expect(ctx.bestMs).toBe(287);
+    expect(ctx.isNewBest).toBe(true);
+  });
+
+  it('result with non-best keeps existing bestMs and clears isNewBest', () => {
+    let ctx = reduce(initialContext({ bestMs: 200 }), { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
+    expect(ctx.bestMs).toBe(200);
+    expect(ctx.isNewBest).toBe(false);
+  });
+
+  it('result with no prior best treats first time as a new best', () => {
+    let ctx = reduce(initialContext({ bestMs: null }), { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
+    expect(ctx.bestMs).toBe(287);
+    expect(ctx.isNewBest).toBe(true);
+  });
+
+  it('result + RACE_AGAIN transitions to arming and clears reactionMs', () => {
+    let ctx = reduce(initialContext({ bestMs: null }), { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
+    ctx = reduce(ctx, { type: 'RACE_AGAIN' });
+    expect(ctx.state).toBe('arming');
+    expect(ctx.reactionMs).toBe(null);
+  });
+
+  it('jumpStart + JUMP_START_RECOVERED returns to idle', () => {
+    let ctx = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 100 });
+    expect(ctx.state).toBe('jumpStart');
+    ctx = reduce(ctx, { type: 'JUMP_START_RECOVERED' });
+    expect(ctx.state).toBe('idle');
+  });
+
+  it('OPEN resets the context to idle while preserving bestMs', () => {
+    let ctx = reduce(initialContext({ bestMs: 250 }), { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'OPEN' });
+    expect(ctx.state).toBe('idle');
+    expect(ctx.bestMs).toBe(250);
+    expect(ctx.reactionMs).toBe(null);
+    expect(ctx.liveStartTime).toBe(null);
+    expect(ctx.isNewBest).toBe(false);
+  });
+
+  it('ignores irrelevant events without changing state', () => {
+    const next = reduce(baseCtx, { type: 'LIGHTS_OUT', timestamp: 1000 });
+    expect(next).toBe(baseCtx);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test`
+
+Expected: all tests fail with "Cannot find module '../state'" (or similar).
+
+- [ ] **Step 3: Implement the state machine**
+
+Create `src/components/lights-out/state.ts`:
+
+```ts
+export type State =
+  | 'idle'
+  | 'arming'
+  | 'holding'
+  | 'live'
+  | 'result'
+  | 'jumpStart';
+
+export type GameEvent =
+  | { type: 'OPEN' }
+  | { type: 'INPUT'; timestamp: number }
+  | { type: 'LIGHTS_ARMED' }
+  | { type: 'LIGHTS_OUT'; timestamp: number }
+  | { type: 'JUMP_START_RECOVERED' }
+  | { type: 'RACE_AGAIN' };
+
+export interface Context {
+  state: State;
+  liveStartTime: number | null;
+  reactionMs: number | null;
+  bestMs: number | null;
+  isNewBest: boolean;
+}
+
+export function initialContext(opts: { bestMs: number | null }): Context {
+  return {
+    state: 'idle',
+    liveStartTime: null,
+    reactionMs: null,
+    bestMs: opts.bestMs,
+    isNewBest: false,
+  };
+}
+
+export function reduce(ctx: Context, event: GameEvent): Context {
+  switch (event.type) {
+    case 'OPEN':
+      return {
+        ...ctx,
+        state: 'idle',
+        liveStartTime: null,
+        reactionMs: null,
+        isNewBest: false,
+      };
+
+    case 'INPUT':
+      if (ctx.state === 'idle') {
+        return { ...ctx, state: 'arming' };
+      }
+      if (ctx.state === 'arming' || ctx.state === 'holding') {
+        return { ...ctx, state: 'jumpStart' };
+      }
+      if (ctx.state === 'live' && ctx.liveStartTime !== null) {
+        const reactionMs = event.timestamp - ctx.liveStartTime;
+        const isNewBest = ctx.bestMs === null || reactionMs < ctx.bestMs;
+        return {
+          ...ctx,
+          state: 'result',
+          reactionMs,
+          isNewBest,
+          bestMs: isNewBest ? reactionMs : ctx.bestMs,
+        };
+      }
+      return ctx;
+
+    case 'LIGHTS_ARMED':
+      if (ctx.state === 'arming') {
+        return { ...ctx, state: 'holding' };
+      }
+      return ctx;
+
+    case 'LIGHTS_OUT':
+      if (ctx.state === 'holding') {
+        return { ...ctx, state: 'live', liveStartTime: event.timestamp };
+      }
+      return ctx;
+
+    case 'JUMP_START_RECOVERED':
+      if (ctx.state === 'jumpStart') {
+        return { ...ctx, state: 'idle' };
+      }
+      return ctx;
+
+    case 'RACE_AGAIN':
+      if (ctx.state === 'result' || ctx.state === 'idle') {
+        return { ...ctx, state: 'arming', reactionMs: null, liveStartTime: null, isNewBest: false };
+      }
+      return ctx;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test`
+
+Expected: all 13 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/lights-out/state.ts src/components/lights-out/__tests__/state.test.ts
+git commit -m "Add lights-out state machine with unit tests"
+```
+
+---
+
+## Task 3: localStorage helpers (TDD)
+
+**Files:**
+
+- Create: `src/components/lights-out/storage.ts`
+- Create: `src/components/lights-out/__tests__/storage.test.ts`
+
+Defensive helpers — must not crash if localStorage is unavailable, contains garbage, or is full.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/components/lights-out/__tests__/storage.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readBestMs, writeBestMs, readSoundEnabled, writeSoundEnabled } from '../storage';
+
+describe('lights-out storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('bestMs', () => {
+    it('returns null when key is missing', () => {
+      expect(readBestMs()).toBe(null);
+    });
+
+    it('returns null for non-numeric values', () => {
+      localStorage.setItem('lightsOut.bestMs', 'not-a-number');
+      expect(readBestMs()).toBe(null);
+    });
+
+    it('returns null for negative values', () => {
+      localStorage.setItem('lightsOut.bestMs', '-5');
+      expect(readBestMs()).toBe(null);
+    });
+
+    it('returns null for NaN', () => {
+      localStorage.setItem('lightsOut.bestMs', 'NaN');
+      expect(readBestMs()).toBe(null);
+    });
+
+    it('returns the stored number when valid', () => {
+      localStorage.setItem('lightsOut.bestMs', '287');
+      expect(readBestMs()).toBe(287);
+    });
+
+    it('round-trips a written value', () => {
+      writeBestMs(241);
+      expect(readBestMs()).toBe(241);
+    });
+  });
+
+  describe('soundEnabled', () => {
+    it('defaults to false when missing', () => {
+      expect(readSoundEnabled()).toBe(false);
+    });
+
+    it('reads "true" as true', () => {
+      localStorage.setItem('lightsOut.soundEnabled', 'true');
+      expect(readSoundEnabled()).toBe(true);
+    });
+
+    it('reads anything else as false', () => {
+      localStorage.setItem('lightsOut.soundEnabled', 'yes');
+      expect(readSoundEnabled()).toBe(false);
+    });
+
+    it('round-trips a written boolean', () => {
+      writeSoundEnabled(true);
+      expect(readSoundEnabled()).toBe(true);
+      writeSoundEnabled(false);
+      expect(readSoundEnabled()).toBe(false);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test`
+
+Expected: all 10 tests fail (module not found).
+
+- [ ] **Step 3: Implement the storage helpers**
+
+Create `src/components/lights-out/storage.ts`:
+
+```ts
+const KEY_BEST_MS = 'lightsOut.bestMs';
+const KEY_SOUND_ENABLED = 'lightsOut.soundEnabled';
+
+function safeGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // localStorage unavailable or full; ignore.
+  }
+}
+
+export function readBestMs(): number | null {
+  const raw = safeGet(KEY_BEST_MS);
+  if (raw === null) return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
+export function writeBestMs(ms: number): void {
+  if (!Number.isFinite(ms) || ms < 0) return;
+  safeSet(KEY_BEST_MS, String(ms));
+}
+
+export function readSoundEnabled(): boolean {
+  return safeGet(KEY_SOUND_ENABLED) === 'true';
+}
+
+export function writeSoundEnabled(enabled: boolean): void {
+  safeSet(KEY_SOUND_ENABLED, enabled ? 'true' : 'false');
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test`
+
+Expected: all 23 tests (13 from Task 2 + 10 new) pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/lights-out/storage.ts src/components/lights-out/__tests__/storage.test.ts
+git commit -m "Add defensive localStorage helpers for lights-out"
+```
+
+---
+
+## Task 4: Sound module
+
+**Files:**
+
+- Create: `src/components/lights-out/sound.ts`
+
+The sound module is small, hard to unit test (Web Audio is an oral DOM API), and called from a single place. We skip TDD here and rely on manual verification.
+
+- [ ] **Step 1: Implement the sound module**
+
+Create `src/components/lights-out/sound.ts`:
+
+```ts
+let ctx: AudioContext | null = null;
+
+function getContext(): AudioContext | null {
+  if (ctx) return ctx;
+  try {
+    const Ctor = window.AudioContext ?? (window as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctor) return null;
+    ctx = new Ctor();
+    return ctx;
+  } catch {
+    return null;
+  }
+}
+
+function playTone(frequency: number, durationMs: number): void {
+  const audio = getContext();
+  if (!audio) return;
+
+  const osc = audio.createOscillator();
+  const gain = audio.createGain();
+  osc.type = 'square';
+  osc.frequency.setValueAtTime(frequency, audio.currentTime);
+
+  // Quick attack/decay envelope to avoid clicks
+  gain.gain.setValueAtTime(0, audio.currentTime);
+  gain.gain.linearRampToValueAtTime(0.18, audio.currentTime + 0.01);
+  gain.gain.linearRampToValueAtTime(0, audio.currentTime + durationMs / 1000);
+
+  osc.connect(gain);
+  gain.connect(audio.destination);
+  osc.start();
+  osc.stop(audio.currentTime + durationMs / 1000);
+}
+
+/** Higher beep played as each light turns on. */
+export function playLightOn(): void {
+  playTone(880, 120);
+}
+
+/** Lower, longer beep played when all lights extinguish. */
+export function playLightsOut(): void {
+  playTone(440, 250);
+}
+
+/** Resume the AudioContext after a user gesture (required by browser autoplay policy). */
+export function resumeAudio(): void {
+  const audio = getContext();
+  if (audio && audio.state === 'suspended') {
+    void audio.resume();
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/lights-out/sound.ts
+git commit -m "Add Web Audio tone generator for lights-out sound"
+```
+
+---
+
+## Task 5: Overlay markup and styles
+
+**Files:**
+
+- Create: `src/components/lights-out/LightsOut.astro`
+
+This task creates the static markup and scoped styles. The controller (Task 6) will populate the column container, attach listeners, and run animations.
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/lights-out/LightsOut.astro`:
+
+```astro
+---
+// Overlay for the F1 lights-out easter egg.
+// Mounted once globally in BaseLayout.astro. Hidden until the
+// 'lights-out:open' custom event is dispatched on `window`.
+---
+
+<div
+  class="lights-out"
+  data-state="closed"
+  role="dialog"
+  aria-modal="true"
+  aria-label="F1 lights-out reaction game"
+  aria-hidden="true"
+  hidden
+>
+  <!-- Pixel takeover columns are populated by the controller -->
+  <div class="lights-out__pixels" data-pixels></div>
+
+  <!-- Game UI sits above the pixel takeover -->
+  <div class="lights-out__ui">
+    <div class="lights-out__top-bar">
+      <button
+        type="button"
+        class="lights-out__icon-btn"
+        data-sound-toggle
+        aria-label="Toggle sound"
+      >🔇</button>
+      <button
+        type="button"
+        class="lights-out__icon-btn"
+        data-close
+        aria-label="Exit game"
+      >✕</button>
+    </div>
+
+    <div class="lights-out__gantry" data-gantry>
+      <span class="lights-out__bulb" data-bulb="0"></span>
+      <span class="lights-out__bulb" data-bulb="1"></span>
+      <span class="lights-out__bulb" data-bulb="2"></span>
+      <span class="lights-out__bulb" data-bulb="3"></span>
+      <span class="lights-out__bulb" data-bulb="4"></span>
+    </div>
+
+    <div class="lights-out__message" data-message aria-live="polite">
+      PRESS SPACE OR CLICK TO START
+    </div>
+
+    <div class="lights-out__result" data-result hidden>
+      <div class="lights-out__time" data-time>0 MS</div>
+      <div class="lights-out__best" data-best></div>
+      <div class="lights-out__buttons">
+        <button type="button" class="lights-out__btn" data-race-again>RACE AGAIN</button>
+        <button type="button" class="lights-out__btn" data-exit>EXIT</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  import { mount } from './controller';
+  mount();
+</script>
+
+<style is:global>
+  .lights-out {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    pointer-events: none;
+    font-family: 'Press Start 2P', system-ui, monospace;
+    color: #fefcf6;
+  }
+
+  .lights-out[data-state='open'],
+  .lights-out[data-state='opening'],
+  .lights-out[data-state='closing'] {
+    pointer-events: auto;
+  }
+
+  /* The pixel-block takeover layer */
+  .lights-out__pixels {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+  }
+
+  .lights-out__pixel-col {
+    position: absolute;
+    bottom: 0;
+    width: var(--col-width, 28px);
+    height: var(--col-height, 120vh);
+    background: #000;
+    transform: translateY(100%);
+    transition: transform var(--rise-duration, 1500ms) cubic-bezier(0.4, 0, 0.6, 1)
+      var(--rise-delay, 0ms);
+  }
+
+  .lights-out[data-state='open'] .lights-out__pixel-col,
+  .lights-out[data-state='opening'] .lights-out__pixel-col {
+    transform: translateY(var(--col-rest-offset, 0));
+  }
+
+  /* Subtle scanlines over the takeover */
+  .lights-out__pixels::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.02) 0,
+      rgba(255, 255, 255, 0.02) 1px,
+      transparent 1px,
+      transparent 3px
+    );
+    pointer-events: none;
+  }
+
+  /* UI layer — transparent to clicks except on its actual content,
+     so clicks pass through empty UI areas to the pixel/gap layer below.
+     Without this, the full-bleed UI container would absorb every click. */
+  .lights-out__ui {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2.5rem;
+    opacity: 0;
+    transition: opacity 250ms ease 800ms;
+    pointer-events: none;
+  }
+
+  .lights-out__top-bar,
+  .lights-out__gantry,
+  .lights-out__message,
+  .lights-out__result {
+    pointer-events: auto;
+  }
+
+  .lights-out[data-state='open'] .lights-out__ui {
+    opacity: 1;
+  }
+
+  .lights-out__top-bar {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .lights-out__icon-btn {
+    background: #000;
+    color: #fefcf6;
+    border: 2px solid #fefcf6;
+    width: 44px;
+    height: 44px;
+    font-size: 1.25rem;
+    cursor: pointer;
+    image-rendering: pixelated;
+  }
+
+  .lights-out__icon-btn:focus-visible {
+    outline: 2px solid #ff1f1f;
+    outline-offset: 2px;
+  }
+
+  .lights-out__gantry {
+    display: flex;
+    gap: 1.25rem;
+  }
+
+  .lights-out__bulb {
+    width: 56px;
+    height: 56px;
+    border: 4px solid #2a0606;
+    background: #1a0303;
+    box-shadow: inset 0 0 0 4px #000;
+    image-rendering: pixelated;
+  }
+
+  .lights-out__bulb[data-on='true'] {
+    background: #ff1f1f;
+    border-color: #ff5555;
+    box-shadow:
+      inset 0 0 0 4px #b71010,
+      0 0 24px rgba(255, 31, 31, 0.7);
+  }
+
+  .lights-out__message {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-align: center;
+    padding: 0 1rem;
+  }
+
+  .lights-out__result {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .lights-out__time {
+    font-size: 2.5rem;
+  }
+
+  .lights-out__time[data-new-best='true'] {
+    color: #ff1f1f;
+  }
+
+  .lights-out__best {
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    color: rgba(254, 252, 246, 0.6);
+    min-height: 1em;
+  }
+
+  .lights-out__buttons {
+    display: flex;
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+
+  .lights-out__btn {
+    background: #000;
+    color: #fefcf6;
+    border: 4px solid #fefcf6;
+    padding: 0.75rem 1.25rem;
+    font-family: inherit;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    image-rendering: pixelated;
+  }
+
+  .lights-out__btn:hover,
+  .lights-out__btn:focus-visible {
+    background: #fefcf6;
+    color: #000;
+    outline: none;
+  }
+
+  /* Jump-start flash */
+  .lights-out__pixels[data-jump-start='true']::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 31, 31, 0.45);
+    animation: lights-out-flash 150ms ease-out;
+  }
+
+  @keyframes lights-out-flash {
+    from { opacity: 1; }
+    to { opacity: 0; }
+  }
+
+  /* Reduced motion: snap takeover in instantly */
+  @media (prefers-reduced-motion: reduce) {
+    .lights-out__pixel-col {
+      transition: none !important;
+    }
+    .lights-out__ui {
+      transition: none !important;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .lights-out__bulb { width: 40px; height: 40px; }
+    .lights-out__gantry { gap: 0.75rem; }
+    .lights-out__time { font-size: 1.75rem; }
+  }
+</style>
+```
+
+- [ ] **Step 2: Format the file with Prettier**
+
+Run: `npx prettier --write src/components/lights-out/LightsOut.astro`
+
+Expected: file formatted in place. (Skipping a build/typecheck here because the controller doesn't exist yet, which would fail the import. The next task implements the controller; we'll verify the full integration in Task 8.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/lights-out/LightsOut.astro
+git commit -m "Add lights-out overlay markup and styles"
+```
+
+---
+
+## Task 6: Controller (DOM wiring, animation, focus)
+
+**Files:**
+
+- Create: `src/components/lights-out/controller.ts`
+
+This is the largest module. It owns the runtime: opening/closing, the rising-pixel animation, ticking through the light sequence, capturing input, trapping focus, and swapping the result UI in/out.
+
+- [ ] **Step 1: Implement the controller**
+
+Create `src/components/lights-out/controller.ts`:
+
+```ts
+import { initialContext, reduce, type Context, type GameEvent } from './state';
+import { readBestMs, writeBestMs, readSoundEnabled, writeSoundEnabled } from './storage';
+import { playLightOn, playLightsOut, resumeAudio } from './sound';
+
+const PIXEL_BLOCK_PX = 28;
+const LIGHT_INTERVAL_MS = 1000;
+const HOLD_MIN_MS = 200;
+const HOLD_MAX_MS = 3000;
+const JUMP_START_COOLDOWN_MS = 2000;
+const NUM_LIGHTS = 5;
+
+type Refs = {
+  root: HTMLElement;
+  pixels: HTMLElement;
+  bulbs: HTMLElement[];
+  message: HTMLElement;
+  result: HTMLElement;
+  time: HTMLElement;
+  best: HTMLElement;
+  raceAgain: HTMLButtonElement;
+  exit: HTMLButtonElement;
+  closeBtn: HTMLButtonElement;
+  soundToggle: HTMLButtonElement;
+};
+
+type Runtime = {
+  refs: Refs;
+  ctx: Context;
+  soundEnabled: boolean;
+  triggerEl: HTMLElement | null;
+  // Pending timers — must be cleared on close to avoid leaks.
+  armingTimers: number[];
+  holdTimer: number | null;
+  jumpStartTimer: number | null;
+};
+
+let runtime: Runtime | null = null;
+
+export function mount(): void {
+  if (runtime) return;
+  if (typeof document === 'undefined') return;
+
+  const root = document.querySelector<HTMLElement>('.lights-out');
+  if (!root) return;
+
+  const refs = collectRefs(root);
+  const soundEnabled = readSoundEnabled();
+  refs.soundToggle.textContent = soundEnabled ? '🔊' : '🔇';
+
+  runtime = {
+    refs,
+    ctx: initialContext({ bestMs: readBestMs() }),
+    soundEnabled,
+    triggerEl: null,
+    armingTimers: [],
+    holdTimer: null,
+    jumpStartTimer: null,
+  };
+
+  attachListeners(runtime);
+}
+
+function collectRefs(root: HTMLElement): Refs {
+  const q = <T extends HTMLElement = HTMLElement>(sel: string): T => {
+    const el = root.querySelector<T>(sel);
+    if (!el) throw new Error(`lights-out: missing element ${sel}`);
+    return el;
+  };
+
+  const bulbs: HTMLElement[] = [];
+  for (let i = 0; i < NUM_LIGHTS; i++) {
+    bulbs.push(q<HTMLElement>(`[data-bulb="${i}"]`));
+  }
+
+  return {
+    root,
+    pixels: q('[data-pixels]'),
+    bulbs,
+    message: q('[data-message]'),
+    result: q('[data-result]'),
+    time: q('[data-time]'),
+    best: q('[data-best]'),
+    raceAgain: q<HTMLButtonElement>('[data-race-again]'),
+    exit: q<HTMLButtonElement>('[data-exit]'),
+    closeBtn: q<HTMLButtonElement>('[data-close]'),
+    soundToggle: q<HTMLButtonElement>('[data-sound-toggle]'),
+  };
+}
+
+function attachListeners(rt: Runtime): void {
+  window.addEventListener('lights-out:open', (event) => {
+    const trigger = (event as CustomEvent<{ trigger?: HTMLElement }>).detail?.trigger ?? null;
+    open(rt, trigger);
+  });
+
+  rt.refs.closeBtn.addEventListener('click', () => close(rt));
+  rt.refs.exit.addEventListener('click', () => close(rt));
+  rt.refs.raceAgain.addEventListener('click', () => {
+    dispatch(rt, { type: 'RACE_AGAIN' });
+  });
+
+  rt.refs.soundToggle.addEventListener('click', () => {
+    rt.soundEnabled = !rt.soundEnabled;
+    writeSoundEnabled(rt.soundEnabled);
+    rt.refs.soundToggle.textContent = rt.soundEnabled ? '🔊' : '🔇';
+    if (rt.soundEnabled) resumeAudio();
+  });
+
+  rt.refs.root.addEventListener('click', (e) => {
+    if (!(e.target instanceof HTMLElement)) return;
+    if (e.target.closest('button')) return; // buttons handle themselves
+
+    // Click landed on a black pixel column or a UI content area = game input.
+    if (
+      e.target.closest('.lights-out__pixel-col') ||
+      e.target.closest('.lights-out__gantry') ||
+      e.target.closest('.lights-out__message') ||
+      e.target.closest('.lights-out__result')
+    ) {
+      dispatch(rt, { type: 'INPUT', timestamp: performance.now() });
+      return;
+    }
+
+    // Anything else — i.e. the transparent gaps in `.lights-out__pixels`
+    // where the portfolio shows through — counts as exit.
+    close(rt);
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (rt.refs.root.dataset.state !== 'open') return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close(rt);
+      return;
+    }
+    if (e.key === 'Tab') {
+      const focusable = getFocusable(rt);
+      if (focusable.length === 0) return;
+      e.preventDefault();
+      const current = document.activeElement;
+      const idx = focusable.indexOf(current as HTMLElement);
+      const next = e.shiftKey
+        ? focusable[idx <= 0 ? focusable.length - 1 : idx - 1]
+        : focusable[idx === -1 || idx === focusable.length - 1 ? 0 : idx + 1];
+      next.focus();
+      return;
+    }
+    if (e.key === ' ' || e.code === 'Space') {
+      e.preventDefault();
+      dispatch(rt, { type: 'INPUT', timestamp: performance.now() });
+    }
+  });
+}
+
+function getFocusable(rt: Runtime): HTMLElement[] {
+  // Returns the overlay's currently visible interactive elements, in tab order.
+  // `offsetParent === null` means the element (or an ancestor) is hidden,
+  // which correctly excludes RACE AGAIN / EXIT while the result panel is hidden.
+  const candidates: HTMLElement[] = [
+    rt.refs.soundToggle,
+    rt.refs.closeBtn,
+    rt.refs.raceAgain,
+    rt.refs.exit,
+  ];
+  return candidates.filter((el) => el.offsetParent !== null);
+}
+
+function open(rt: Runtime, trigger: HTMLElement | null): void {
+  rt.triggerEl = trigger;
+  rt.refs.root.hidden = false;
+  rt.refs.root.setAttribute('aria-hidden', 'false');
+  document.body.style.overflow = 'hidden';
+
+  buildPixels(rt);
+  rt.refs.root.dataset.state = 'opening';
+  // Force a reflow so the transition runs from the initial position.
+  void rt.refs.root.offsetWidth;
+  rt.refs.root.dataset.state = 'open';
+
+  dispatch(rt, { type: 'OPEN' });
+
+  // Move focus into the overlay (close button is a safe initial target).
+  setTimeout(() => rt.refs.closeBtn.focus(), 50);
+}
+
+function close(rt: Runtime): void {
+  clearAllTimers(rt);
+  rt.refs.root.dataset.state = 'closing';
+
+  // Reverse animation: pixels slide back down by clearing the rest offset.
+  for (const col of Array.from(rt.refs.pixels.children) as HTMLElement[]) {
+    col.style.setProperty('--rise-duration', '600ms');
+    col.style.setProperty('--rise-delay', '0ms');
+  }
+  // Force reflow then remove the open data-state to trigger transition.
+  void rt.refs.root.offsetWidth;
+  rt.refs.root.dataset.state = 'closed';
+
+  setTimeout(() => {
+    rt.refs.root.hidden = true;
+    rt.refs.root.setAttribute('aria-hidden', 'true');
+    rt.refs.pixels.replaceChildren();
+    document.body.style.overflow = '';
+    if (rt.triggerEl) rt.triggerEl.focus();
+  }, 650);
+}
+
+function buildPixels(rt: Runtime): void {
+  rt.refs.pixels.replaceChildren();
+  const colCount = Math.ceil(window.innerWidth / PIXEL_BLOCK_PX) + 1;
+  const center = (colCount - 1) / 2;
+  const maxDistance = center;
+
+  const frag = document.createDocumentFragment();
+  for (let i = 0; i < colCount; i++) {
+    const col = document.createElement('div');
+    col.className = 'lights-out__pixel-col';
+    const distance = Math.abs(i - center) / maxDistance; // 0 in middle, 1 at edges
+    const delay = Math.round(distance * 600); // 0–600ms
+    const duration = Math.round(900 + distance * 600); // 900–1500ms
+    const restOffset = -(Math.floor(Math.random() * 4) * 6); // 0, -6, -12, -18 px
+    col.style.setProperty('--col-width', `${PIXEL_BLOCK_PX}px`);
+    col.style.setProperty('--rise-delay', `${delay}ms`);
+    col.style.setProperty('--rise-duration', `${duration}ms`);
+    col.style.setProperty('--col-rest-offset', `${restOffset}px`);
+    col.style.left = `${i * PIXEL_BLOCK_PX}px`;
+    frag.appendChild(col);
+  }
+  rt.refs.pixels.appendChild(frag);
+}
+
+function dispatch(rt: Runtime, event: GameEvent): void {
+  const prev = rt.ctx;
+  rt.ctx = reduce(rt.ctx, event);
+  if (rt.ctx === prev) return;
+  applyState(rt);
+}
+
+function applyState(rt: Runtime): void {
+  const { ctx, refs } = rt;
+
+  switch (ctx.state) {
+    case 'idle':
+      clearAllTimers(rt);
+      refs.bulbs.forEach((b) => (b.dataset.on = 'false'));
+      refs.message.textContent = 'PRESS SPACE OR CLICK TO START';
+      refs.message.hidden = false;
+      refs.result.hidden = true;
+      refs.pixels.dataset.jumpStart = 'false';
+      break;
+
+    case 'arming':
+      refs.message.textContent = 'GET READY';
+      refs.result.hidden = true;
+      refs.bulbs.forEach((b) => (b.dataset.on = 'false'));
+      runArming(rt);
+      break;
+
+    case 'holding':
+      runHolding(rt);
+      break;
+
+    case 'live':
+      // All lights extinguish; visual handled in runHolding's lights-out callback.
+      refs.message.textContent = 'GO!';
+      break;
+
+    case 'result':
+      showResult(rt);
+      break;
+
+    case 'jumpStart':
+      refs.pixels.dataset.jumpStart = 'true';
+      refs.bulbs.forEach((b) => (b.dataset.on = 'false'));
+      refs.message.textContent = '🚨 JUMP START 🚨';
+      refs.result.hidden = true;
+      clearAllTimers(rt);
+      rt.jumpStartTimer = window.setTimeout(() => {
+        refs.pixels.dataset.jumpStart = 'false';
+        dispatch(rt, { type: 'JUMP_START_RECOVERED' });
+      }, JUMP_START_COOLDOWN_MS);
+      break;
+  }
+}
+
+function runArming(rt: Runtime): void {
+  clearAllTimers(rt);
+  for (let i = 0; i < NUM_LIGHTS; i++) {
+    const t = window.setTimeout(
+      () => {
+        if (rt.ctx.state !== 'arming') return;
+        rt.refs.bulbs[i].dataset.on = 'true';
+        if (rt.soundEnabled) playLightOn();
+        if (i === NUM_LIGHTS - 1) {
+          dispatch(rt, { type: 'LIGHTS_ARMED' });
+        }
+      },
+      LIGHT_INTERVAL_MS * (i + 1),
+    );
+    rt.armingTimers.push(t);
+  }
+}
+
+function runHolding(rt: Runtime): void {
+  const delay = HOLD_MIN_MS + Math.random() * (HOLD_MAX_MS - HOLD_MIN_MS);
+  rt.holdTimer = window.setTimeout(() => {
+    if (rt.ctx.state !== 'holding') return;
+    rt.refs.bulbs.forEach((b) => (b.dataset.on = 'false'));
+    if (rt.soundEnabled) playLightsOut();
+    dispatch(rt, { type: 'LIGHTS_OUT', timestamp: performance.now() });
+  }, delay);
+}
+
+function showResult(rt: Runtime): void {
+  const { ctx, refs } = rt;
+  if (ctx.reactionMs === null) return;
+
+  refs.message.hidden = true;
+  refs.result.hidden = false;
+  refs.time.textContent = `${Math.round(ctx.reactionMs)} MS`;
+  refs.time.dataset.newBest = ctx.isNewBest ? 'true' : 'false';
+
+  if (ctx.isNewBest) {
+    refs.best.textContent = 'NEW PERSONAL BEST!';
+    if (ctx.bestMs !== null) writeBestMs(Math.round(ctx.bestMs));
+  } else if (ctx.bestMs !== null) {
+    refs.best.textContent = `BEST: ${Math.round(ctx.bestMs)} MS`;
+  } else {
+    refs.best.textContent = '';
+  }
+
+  refs.raceAgain.focus();
+}
+
+function clearAllTimers(rt: Runtime): void {
+  rt.armingTimers.forEach((t) => clearTimeout(t));
+  rt.armingTimers = [];
+  if (rt.holdTimer !== null) {
+    clearTimeout(rt.holdTimer);
+    rt.holdTimer = null;
+  }
+  if (rt.jumpStartTimer !== null) {
+    clearTimeout(rt.jumpStartTimer);
+    rt.jumpStartTimer = null;
+  }
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run build 2>&1 | tail -30`
+
+Expected: build succeeds with no TypeScript errors and `dist/` is produced. Astro's build pipeline runs the type checker over `.astro` and `.ts` files.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/lights-out/controller.ts
+git commit -m "Add lights-out controller wiring DOM, animation, focus"
+```
+
+---
+
+## Task 7: Footer trigger (centered checkered flag)
+
+**Files:**
+
+- Modify: `src/components/layout/Footer.astro`
+
+The current bottom bar uses a 2-element `justify-between` flex. We restructure it to a 3-element layout with the flag in the middle. On the small breakpoint where the bar wraps to a column, the flag stays between the two text elements.
+
+- [ ] **Step 1: Read the current footer**
+
+Run: `cat src/components/layout/Footer.astro`
+
+Expected: file contents matching the spec context.
+
+- [ ] **Step 2: Replace the bottom bar with a 3-element layout**
+
+Edit `src/components/layout/Footer.astro`. Replace the current `<!-- Bottom bar -->` block with:
+
+```astro
+    <!-- Bottom bar -->
+    <div
+      class="mt-10 pt-6 border-t border-cream/10 flex flex-col sm:flex-row sm:justify-between items-center gap-2 text-cream/30 text-xs"
+    >
+      <p class="order-1">© {currentYear} {personalInfo.name}. All rights reserved.</p>
+
+      <button
+        type="button"
+        class="lights-out-trigger order-2 text-cream/30 hover:text-cream focus-visible:text-cream transition-colors duration-200"
+        aria-label="Open F1 lights-out reaction game"
+        title="ready to race?"
+      >
+        <span aria-hidden="true">🏁</span>
+      </button>
+
+      <p class="order-3">Built with Astro + Tailwind.</p>
+    </div>
+```
+
+- [ ] **Step 3: Add the trigger script at the end of the file**
+
+After the closing `</footer>` tag, append:
+
+```astro
+<script>
+  document.querySelectorAll<HTMLButtonElement>('.lights-out-trigger').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      window.dispatchEvent(
+        new CustomEvent('lights-out:open', { detail: { trigger: btn } }),
+      );
+    });
+  });
+</script>
+```
+
+- [ ] **Step 4: Verify the footer builds**
+
+Run: `npm run build 2>&1 | tail -20`
+
+Expected: build succeeds. The footer trigger is wired but the overlay isn't mounted yet (that's Task 8) — clicking the flag in dev would dispatch an event no one is listening for, which is harmless.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/layout/Footer.astro
+git commit -m "Add centered checkered-flag trigger to footer"
+```
+
+---
+
+## Task 8: BaseLayout integration
+
+**Files:**
+
+- Modify: `src/components/layout/BaseLayout.astro`
+
+Mount the overlay component once and add the Press Start 2P stylesheet.
+
+- [ ] **Step 1: Add the import for LightsOut**
+
+Edit `src/components/layout/BaseLayout.astro`. In the frontmatter (between the `---` fences), below the existing `import` line, add:
+
+```astro
+import LightsOut from '../lights-out/LightsOut.astro';
+```
+
+So the frontmatter becomes:
+
+```astro
+---
+import '../../styles/global.css';
+import LightsOut from '../lights-out/LightsOut.astro';
+
+interface Props {
+  title?: string;
+  description?: string;
+}
+
+const {
+  title = "Sarah O'Keefe — Front-End Engineer",
+  description =
+    "Front-end software engineer based in Charlotte, NC. Building things with React and TypeScript at iHeartRadio.",
+} = Astro.props;
+---
+```
+
+- [ ] **Step 2: Add `Press Start 2P` to the existing Google Fonts stylesheet link**
+
+Find the existing line:
+
+```astro
+<link
+  href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap"
+  rel="stylesheet"
+/>
+```
+
+Replace it with:
+
+```astro
+<link
+  href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@300;400;500;600&family=Press+Start+2P&display=swap"
+  rel="stylesheet"
+/>
+```
+
+- [ ] **Step 3: Mount the overlay after the slot**
+
+Inside the `<body>`, replace:
+
+```astro
+<body>
+  <slot />
+</body>
+```
+
+with:
+
+```astro
+<body>
+  <slot />
+  <LightsOut />
+</body>
+```
+
+- [ ] **Step 4: Verify the integrated layout builds**
+
+Run: `npm run build 2>&1 | tail -20`
+
+Expected: build succeeds, `dist/` produced, no TypeScript errors. This is the first end-to-end verification that everything wires together.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/layout/BaseLayout.astro
+git commit -m "Mount lights-out overlay globally and load Press Start 2P"
+```
+
+---
+
+## Task 9: Manual smoke test
+
+This task is hands-on in the browser. Document any issues found and fix before the final commit.
+
+- [ ] **Step 1: Run dev server**
+
+Run: `npm run dev`
+
+Open the URL printed (usually http://localhost:4321).
+
+- [ ] **Step 2: Verify the trigger glyph**
+
+- Scroll to the footer.
+- The `🏁` glyph should sit exactly between the copyright (left) and "Built with Astro + Tailwind" (right) on desktop.
+- On a narrow viewport (< 640px), the bar wraps; the flag should be the middle of the three vertically stacked items.
+- Hovering should brighten the flag from `cream/30` to `cream`.
+- The browser tooltip should read "ready to race?".
+
+- [ ] **Step 3: Verify the takeover animation**
+
+- Click the flag.
+- Black columns should rise from the bottom of the viewport: middle columns first/fastest, edge columns slower. Total ~1.5s.
+- After settling, the top edge should be slightly jagged (some columns visibly shorter than others).
+- The portfolio should remain visible around the irregular edges.
+- The light gantry and prompt should fade in.
+
+- [ ] **Step 4: Play a clean round**
+
+- Press Space (or click anywhere on the black area). Lights should turn on one per ~1s.
+- After all 5 are lit, wait the random hold (200–3000ms).
+- All lights extinguish simultaneously. Press Space.
+- Result should display in `<reaction>ms` form, with `BEST: <ms> MS` below (or `NEW PERSONAL BEST!` flash if the first round).
+
+- [ ] **Step 5: Verify the jump-start rule**
+
+- Reload, click the flag, click anywhere on the black area to start, then click again before all 5 lights extinguish.
+- Expected: red flash, `🚨 JUMP START 🚨` message, ~2s cooldown, then back to the ready state.
+
+- [ ] **Step 6: Verify exit options**
+
+- `Esc` key closes the overlay; the pixel columns rush back down.
+- The `X` button closes the overlay.
+- Clicking on visible portfolio area (around the pixel edges) closes the overlay.
+- Focus returns to the flag in the footer after closing.
+
+- [ ] **Step 7: Verify sound toggle**
+
+- Click the speaker icon in the top-right. It should switch from 🔇 to 🔊.
+- Play a round — beeps on each light, lower beep on lights-out.
+- Reload the page, open the overlay; sound should still be enabled (localStorage persisted).
+- Toggle off and reload to confirm the off state persists too.
+
+- [ ] **Step 8: Verify persistence**
+
+- After the first round, `localStorage` should contain `lightsOut.bestMs` with your time.
+- Open dev tools → Application → Local Storage. Confirm.
+- Reload, play another round slower than the best; the displayed `BEST:` should still match your earlier best.
+
+- [ ] **Step 9: Verify accessibility**
+
+- Tab through the page; the flag should be reachable in the footer with a visible focus ring.
+- Inside the overlay, Tab should cycle between the sound toggle, close button, race-again, and exit buttons (focus trap).
+- Try `prefers-reduced-motion: reduce` (DevTools → Rendering → Emulate CSS media feature). Reload and open the overlay — the takeover should snap in instantly without the rising animation.
+
+- [ ] **Step 10: Verify mobile behavior**
+
+- Open DevTools, toggle device emulation to a phone profile.
+- The takeover should still work; the X button should be reachable; tap-to-react should work.
+
+- [ ] **Step 11: Note any issues found**
+
+If any of the above fail, fix in the relevant module before continuing. Common likely issues:
+
+- The flag center alignment on `flex-col` (small viewport): check `order-1/2/3` rendering.
+- Animation feels too fast or slow: tune `LIGHT_INTERVAL_MS`, `HOLD_MIN_MS`, `HOLD_MAX_MS`, `--rise-duration` in `controller.ts` / styles.
+- Pixel column count off by one or columns visible past the right edge: check `colCount` calculation in `buildPixels`.
+
+- [ ] **Step 12: Commit any fixes**
+
+```bash
+git add -p
+git commit -m "Polish lights-out: <describe fix>"
+```
+
+---
+
+## Task 10: Final verification before PR
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test`
+
+Expected: all 23 tests pass.
+
+- [ ] **Step 2: Run the production build**
+
+Run: `npm run build`
+
+Expected: build succeeds, `dist/` produced, no warnings about missing modules.
+
+- [ ] **Step 3: Run Prettier**
+
+Run: `npm run format:check`
+
+If anything fails, run: `npm run format` and commit any formatting changes.
+
+- [ ] **Step 4: Sanity-check commit history**
+
+Run: `git log --oneline origin/master..HEAD`
+
+Expected: a clean sequence of 8–10 commits, one per task.
+
+- [ ] **Step 5: Push the branch**
+
+Run: `git push -u origin feat/f1-easter-egg`
+
+(Only when the user has confirmed they're ready to push — do not push without confirmation.)
+
+---
+
+## Self-review notes
+
+This plan covers each section of the spec:
+
+- **Trigger:** Task 7 (centered flag) + Task 8 (mount).
+- **Site takeover:** Task 5 (markup/styles) + Task 6 (build/animate columns).
+- **Game flow:** Task 2 (state machine) + Task 6 (controller wiring lights, hold, result).
+- **Jump-start rule:** Task 2 (state) + Task 6 (`runArming`/`applyState 'jumpStart'` branch).
+- **Sound:** Task 4 (module) + Task 6 (toggle wiring) + Task 3 (persistence).
+- **Visuals:** Task 5 (CSS).
+- **Architecture:** Tasks 2/3/4/6/8 wire it together via the `lights-out:open` event.
+- **Accessibility:** Task 5 (`role="dialog"`, `aria-modal`, `aria-label`, focus rings) + Task 6 (Esc, focus management, `prefers-reduced-motion` respected via CSS).
+- **Performance:** Task 8 (font preconnect existed, `display=swap` query already present).
+
+**Out of scope (per spec):** leaderboards, multi-round, difficulty modes, additional triggers, mobile haptics, analytics. None added.

--- a/docs/superpowers/specs/2026-05-02-f1-lights-out-easter-egg-design.md
+++ b/docs/superpowers/specs/2026-05-02-f1-lights-out-easter-egg-design.md
@@ -42,7 +42,7 @@ Sarah's bio already mentions that she's "diving deep into the rabbit hole that i
 
 ### Game UI
 
-- Pixel font: `Press Start to Play` from Google Fonts (one weight; preconnect added to `<head>`).
+- Pixel font: `Press Start 2P` from Google Fonts (one weight; preconnect added to `<head>`). The "2P" is just the font's technical name and never appears in UI copy.
 - Color palette inside the takeover deliberately departs from the site's sage/cream:
   - Background: pure black `#000`.
   - Lights when on: neon red `#ff1f1f`.

--- a/docs/superpowers/specs/2026-05-02-f1-lights-out-easter-egg-design.md
+++ b/docs/superpowers/specs/2026-05-02-f1-lights-out-easter-egg-design.md
@@ -1,0 +1,162 @@
+# F1 Lights-Out Easter Egg — Design
+
+**Date:** 2026-05-02
+**Status:** Draft, pending user review
+
+## Motivation
+
+Sarah's bio already mentions that she's "diving deep into the rabbit hole that is Formula 1." A small F1 easter egg gives the portfolio site a memorable, personality-revealing detail — the kind of thing a recruiter or curious visitor stumbles on and remembers. The trigger should be discoverable but not loud; the payoff should feel like a deliberate aesthetic choice, not a gimmick.
+
+## Goals
+
+- A recognizable F1 reference (the start-light reaction-time test) anyone familiar with the sport will immediately appreciate.
+- A "site takeover" moment that's visually striking but easy to escape from.
+- Self-contained — no new dependencies beyond a single Google Font; no framework added; safe to remove.
+- Works on desktop and mobile.
+
+## Non-goals
+
+- Leaderboards, sharing, social integrations.
+- Multi-round / best-of-N modes.
+- Difficulty settings.
+- A second easter egg surface (Konami code, hidden URL, etc.) — the architecture should not preclude these, but they're out of scope for this spec.
+
+## User flow
+
+1. Visitor scrolls to the footer and notices a small `🏁` glyph next to "Built with Astro + Tailwind."
+2. Hovering brightens the glyph; a `title="ready to race?"` tooltip hints at clickability.
+3. Clicking dispatches a `lights-out:open` custom event on `window`.
+4. A fullscreen overlay listens for that event and runs a "pixel takeover" animation: chunky black blocks rise from the bottom of the viewport in independent columns, fastest in the middle and slower at the edges, producing a naturally jagged leading edge. Total animation ~1.5s.
+5. Once settled, the F1 light gantry fades in over the black background. The portfolio remains visible around the irregular pixel edges.
+6. The visitor plays the lights-out reaction-time game (see Game mechanics).
+7. Exit options: `X` button top-right, `Esc` key, or clicking on any visible portfolio area around the takeover. On exit, the pixel blocks rush back down (~600ms) and scroll position is restored.
+
+## Visual design
+
+### Pixel takeover
+
+- Pixel "blocks" are pure black, ~24-32px square. Exact size finalized in implementation; pick a value that divides cleanly into common viewport widths.
+- Animation: each column rises independently. The middle columns start first and fastest; columns toward the edges start later and rise more slowly. Within a column, blocks stack with a slight cascade (~80ms apart in the avalanche phase).
+- The leading edge is naturally irregular during the rise. Once columns settle, the top edge stays slightly jagged (column heights differ by 1-3 blocks), so portfolio peeks through gaps and around the edges.
+- A subtle scanline overlay (CSS `repeating-linear-gradient`) adds CRT flavor without cost.
+
+### Game UI
+
+- Pixel font: `Press Start 2P` from Google Fonts (one weight; preconnect added to `<head>`).
+- Color palette inside the takeover deliberately departs from the site's sage/cream:
+  - Background: pure black `#000`.
+  - Lights when on: neon red `#ff1f1f`.
+  - Text: cream `#FEFCF6` (the one tie back to site palette).
+- Five horizontal "bulbs" laid out across the upper third of the takeover, sized for both viewports.
+- `image-rendering: pixelated` and chunky borders reinforce the 8-bit feel.
+
+### Controls overlay
+
+- Top-right of the takeover: speaker icon (`🔇`/`🔊`) and `X` button. Both opaque so they stay readable over jagged pixel edges.
+- Bottom of the screen during ready/results states: chunky pixel-button labels (`PRESS SPACE OR CLICK TO START`, `RACE AGAIN`, `EXIT`).
+
+## Game mechanics
+
+### States
+
+`idle` → `arming` → `holding` → `live` → `result` → (back to `arming` or exit)
+Plus `jumpStart` as an interrupt from `arming` or `holding` that returns to `idle` after a 2-second cooldown.
+
+### Sequence
+
+1. **idle** — ready screen, prompt visible. Game input (Space or click/tap inside the takeover) transitions to `arming`.
+2. **arming** — lights begin turning on, one per ~1000ms, until all 5 are red. Game input here = jump start.
+3. **holding** — random 200-3000ms delay with all 5 lit. Game input here = jump start.
+4. **live** — all 5 lights extinguish simultaneously; timer starts. The next game input stops the timer and transitions to `result`.
+5. **result** — display reaction time in big chunky type. Compare to localStorage `lightsOut.bestMs`:
+   - If new best: `NEW PERSONAL BEST!` flash; save the new value.
+   - Otherwise: `BEST: 241 MS` shown below the current time.
+   Buttons: `RACE AGAIN` transitions directly to `arming` (auto-starts the next round, no need to "ready up" again). `EXIT` closes the overlay.
+
+### Input zones
+
+- Click/tap on the **black takeover area** = game input (start, react, jump-start trigger).
+- Click/tap on **visible portfolio** around or through the pixel gaps = exit.
+- Spacebar = game input only (never exits; `Esc` exits).
+
+This zoning makes intent unambiguous — clicking the black is "I'm playing"; clicking the portfolio is "I'm done."
+
+### Jump-start rule
+
+Any game input during `arming` or `holding` triggers `jumpStart`:
+- Red flash overlay (~150ms).
+- Big text: `🚨 JUMP START 🚨`.
+- 2-second forced cooldown — input ignored.
+- Returns to `idle`.
+
+This is faithful to the F1 rule; visitors familiar with the sport will recognize and appreciate it.
+
+## Sound (opt-in)
+
+- Speaker icon top-right toggles `lightsOut.soundEnabled` in localStorage. Default off.
+- When enabled:
+  - Each light coming on plays a short beep via Web Audio API (`OscillatorNode`).
+  - Lights-out plays a lower beep.
+  - No audio files shipped; tones are synthesized in-browser.
+- AudioContext is created lazily on first toggle to avoid autoplay-policy issues.
+
+## Architecture
+
+### File layout
+
+- `src/components/lights-out/LightsOut.astro` — the overlay component. Includes:
+  - Markup for the takeover container, light gantry, prompt/result text, control buttons.
+  - A single `<script>` block (vanilla TypeScript) implementing the state machine, animation, input handling, sound, and localStorage interaction.
+- `src/components/layout/Footer.astro` — adds the `🏁` trigger button and dispatches `lights-out:open` on click.
+- `src/layouts/BaseLayout.astro` — mounts `<LightsOut />` once, after the main content, so it's available on every page.
+
+### Communication
+
+- The footer trigger and the overlay communicate via a `window` custom event named `lights-out:open`.
+- This decoupling means future triggers (Konami code, hidden URL, easter-egg-elsewhere) can dispatch the same event without touching the overlay component.
+
+### Persistence
+
+- `localStorage` keys (string-prefixed for clarity):
+  - `lightsOut.bestMs` — number, milliseconds. Best reaction time across visits.
+  - `lightsOut.soundEnabled` — `"true"` or `"false"`.
+- Both are read defensively (try/catch and `Number.isFinite` check) so localStorage failures or tampering don't break the game.
+
+### Why no framework
+
+The site is Astro static + Tailwind. The game is small and self-contained. A vanilla TS `<script>` keeps the bundle lean and matches the existing project pattern. No React/Preact/Solid added.
+
+### Why a single overlay (not a route)
+
+The user explicitly chose "site takeover" rather than navigation away. A route would lose the "the portfolio is still there behind it" effect that the click-through-to-exit relies on.
+
+## Accessibility
+
+- The trigger glyph has an accessible label (`aria-label="Open F1 lights-out reaction game"`).
+- The overlay is a `<dialog>` element (or `role="dialog"` with `aria-modal="true"`) so screen readers handle it correctly.
+- `Esc` always exits.
+- Focus is trapped inside the overlay while open and returned to the trigger on close.
+- The takeover animation respects `prefers-reduced-motion`: if set, the takeover snaps in instantly (no rising-pixel animation), but the game itself still runs.
+- All interactive elements have visible focus rings.
+- The game requires reaction time and is therefore not playable by everyone — that's inherent to the concept. The site itself remains fully accessible; the easter egg is opt-in.
+
+## Performance
+
+- Press Start 2P loaded via Google Fonts with `font-display: swap` and a `<link rel="preconnect">` in `BaseLayout.astro`.
+- The pixel takeover is rendered with CSS-animated divs (one per column or one per block, decided in implementation). No canvas. No images.
+- Total added JS, gzipped: target < 5KB.
+- The overlay markup is present in the DOM on every page but hidden via `display: none` until the event fires, so it has zero visual cost on initial paint.
+
+## Out of scope
+
+- Pixel-art SVG/PNG assets (DOM + CSS only).
+- Leaderboards, sharing, score export.
+- Multi-round / best-of-N.
+- Difficulty modes.
+- Additional easter-egg triggers (Konami, hidden URL).
+- Mobile haptic feedback.
+- Analytics / tracking on the easter egg.
+
+## Open questions
+
+None. All decisions are captured above.

--- a/docs/superpowers/specs/2026-05-02-f1-lights-out-easter-egg-design.md
+++ b/docs/superpowers/specs/2026-05-02-f1-lights-out-easter-egg-design.md
@@ -23,7 +23,7 @@ Sarah's bio already mentions that she's "diving deep into the rabbit hole that i
 
 ## User flow
 
-1. Visitor scrolls to the footer and notices a small `🏁` glyph next to "Built with Astro + Tailwind."
+1. Visitor scrolls to the footer and notices a small `🏁` glyph centered in the bottom bar — exactly between the copyright text on the left and "Built with Astro + Tailwind" on the right. The deliberate center placement is itself the clue: there's no obvious functional reason for a checkered flag to live there, which invites curiosity.
 2. Hovering brightens the glyph; a `title="ready to race?"` tooltip hints at clickability.
 3. Clicking dispatches a `lights-out:open` custom event on `window`.
 4. A fullscreen overlay listens for that event and runs a "pixel takeover" animation: chunky black blocks rise from the bottom of the viewport in independent columns, fastest in the middle and slower at the edges, producing a naturally jagged leading edge. Total animation ~1.5s.
@@ -42,7 +42,7 @@ Sarah's bio already mentions that she's "diving deep into the rabbit hole that i
 
 ### Game UI
 
-- Pixel font: `Press Start 2P` from Google Fonts (one weight; preconnect added to `<head>`).
+- Pixel font: `Press Start to Play` from Google Fonts (one weight; preconnect added to `<head>`).
 - Color palette inside the takeover deliberately departs from the site's sage/cream:
   - Background: pure black `#000`.
   - Lights when on: neon red `#ff1f1f`.
@@ -71,7 +71,7 @@ Plus `jumpStart` as an interrupt from `arming` or `holding` that returns to `idl
 5. **result** — display reaction time in big chunky type. Compare to localStorage `lightsOut.bestMs`:
    - If new best: `NEW PERSONAL BEST!` flash; save the new value.
    - Otherwise: `BEST: 241 MS` shown below the current time.
-   Buttons: `RACE AGAIN` transitions directly to `arming` (auto-starts the next round, no need to "ready up" again). `EXIT` closes the overlay.
+     Buttons: `RACE AGAIN` transitions directly to `arming` (auto-starts the next round, no need to "ready up" again). `EXIT` closes the overlay.
 
 ### Input zones
 
@@ -84,6 +84,7 @@ This zoning makes intent unambiguous — clicking the black is "I'm playing"; cl
 ### Jump-start rule
 
 Any game input during `arming` or `holding` triggers `jumpStart`:
+
 - Red flash overlay (~150ms).
 - Big text: `🚨 JUMP START 🚨`.
 - 2-second forced cooldown — input ignored.
@@ -107,7 +108,7 @@ This is faithful to the F1 rule; visitors familiar with the sport will recognize
 - `src/components/lights-out/LightsOut.astro` — the overlay component. Includes:
   - Markup for the takeover container, light gantry, prompt/result text, control buttons.
   - A single `<script>` block (vanilla TypeScript) implementing the state machine, animation, input handling, sound, and localStorage interaction.
-- `src/components/layout/Footer.astro` — adds the `🏁` trigger button and dispatches `lights-out:open` on click.
+- `src/components/layout/Footer.astro` — adds the `🏁` trigger button (centered in the bottom bar between the copyright and "Built with Astro + Tailwind") and dispatches `lights-out:open` on click. The bottom bar currently uses a 2-element `justify-between` flex; this becomes a 3-element layout with the flag in the middle. On the small breakpoint where the bar wraps to a column, the flag should still sit between the two text elements vertically.
 - `src/layouts/BaseLayout.astro` — mounts `<LightsOut />` once, after the main content, so it's available on every page.
 
 ### Communication

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,10 @@
         "tailwindcss": "^3.4.17"
       },
       "devDependencies": {
+        "jsdom": "^25.0.1",
         "prettier": "^3.8.3",
-        "prettier-plugin-astro": "^0.14.1"
+        "prettier-plugin-astro": "^0.14.1",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -30,6 +32,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@astrojs/compiler": {
       "version": "4.0.0",
@@ -188,6 +211,121 @@
       },
       "engines": {
         "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1677,6 +1815,102 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1737,6 +1971,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astro": {
@@ -1815,6 +2059,13 @@
       "optionalDependencies": {
         "sharp": "^0.34.0"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
@@ -1946,6 +2197,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1985,6 +2260,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -2013,6 +2305,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2073,6 +2375,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/comma-separated-tokens": {
@@ -2217,6 +2532,41 @@
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2234,6 +2584,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -2247,11 +2604,31 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/defu": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -2394,6 +2771,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.348",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.348.tgz",
@@ -2412,6 +2804,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -2426,6 +2828,35 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -2500,6 +2931,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2627,6 +3068,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -2663,6 +3121,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -2681,6 +3178,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/h3": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
@@ -2696,6 +3206,35 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -2887,6 +3426,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -2908,6 +3460,47 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -3035,6 +3628,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-wsl": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -3071,6 +3671,47 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -3098,6 +3739,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "11.3.5",
@@ -3136,6 +3784,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -3966,6 +4624,29 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -4070,6 +4751,13 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4217,6 +4905,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
@@ -4484,6 +5189,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
@@ -4847,6 +5562,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4877,6 +5599,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sass-formatter": {
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
@@ -4894,6 +5623,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -4972,6 +5714,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -5008,6 +5757,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -5101,6 +5864,13 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -5178,6 +5948,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyclip": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
@@ -5212,6 +5989,56 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5222,6 +6049,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -5724,6 +6577,526 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vitefu": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
@@ -5743,6 +7116,619 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -5753,6 +7739,54 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which-pm-runs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
@@ -5761,6 +7795,62 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "astro preview",
     "astro": "astro",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.15",
@@ -20,7 +22,9 @@
   "author": "Sarah O'Keefe",
   "license": "ISC",
   "devDependencies": {
+    "jsdom": "^25.0.1",
     "prettier": "^3.8.3",
-    "prettier-plugin-astro": "^0.14.1"
+    "prettier-plugin-astro": "^0.14.1",
+    "vitest": "^2.1.9"
   }
 }

--- a/src/components/layout/BaseLayout.astro
+++ b/src/components/layout/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../../styles/global.css';
+import LightsOut from '../lights-out/LightsOut.astro';
 
 interface Props {
   title?: string;
@@ -41,7 +42,7 @@ const {
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@300;400;500;600&family=Press+Start+2P&display=swap"
       rel="stylesheet"
     />
 
@@ -62,5 +63,6 @@ const {
   </head>
   <body>
     <slot />
+    <LightsOut />
   </body>
 </html>

--- a/src/components/layout/BaseLayout.astro
+++ b/src/components/layout/BaseLayout.astro
@@ -9,8 +9,7 @@ interface Props {
 
 const {
   title = "Sarah O'Keefe — Front-End Engineer",
-  description =
-    "Front-end software engineer based in Charlotte, NC. Building things with React and TypeScript at iHeartRadio.",
+  description = 'Front-end software engineer based in Charlotte, NC. Building things with React and TypeScript at iHeartRadio.',
 } = Astro.props;
 ---
 
@@ -32,7 +31,9 @@ const {
     <script is:inline>
       (function () {
         const stored = localStorage.getItem('theme');
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const prefersDark = window.matchMedia(
+          '(prefers-color-scheme: dark)',
+        ).matches;
         const theme = stored ?? (prefersDark ? 'dark' : 'light');
         document.documentElement.classList.toggle('dark', theme === 'dark');
       })();

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -46,7 +46,10 @@ const currentYear = new Date().getFullYear();
     <div
       class="mt-10 pt-6 border-t border-cream/10 flex flex-col sm:flex-row sm:justify-between items-center gap-2 text-cream/30 text-xs"
     >
-      <p class="order-1">© {currentYear} {personalInfo.name}. All rights reserved.</p>
+      <p class="order-1">
+        © {currentYear}
+        {personalInfo.name}. All rights reserved.
+      </p>
 
       <button
         type="button"
@@ -63,11 +66,13 @@ const currentYear = new Date().getFullYear();
 </footer>
 
 <script>
-  document.querySelectorAll<HTMLButtonElement>('.lights-out-trigger').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      window.dispatchEvent(
-        new CustomEvent('lights-out:open', { detail: { trigger: btn } }),
-      );
+  document
+    .querySelectorAll<HTMLButtonElement>('.lights-out-trigger')
+    .forEach((btn) => {
+      btn.addEventListener('click', () => {
+        window.dispatchEvent(
+          new CustomEvent('lights-out:open', { detail: { trigger: btn } }),
+        );
+      });
     });
-  });
 </script>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -44,10 +44,30 @@ const currentYear = new Date().getFullYear();
 
     <!-- Bottom bar -->
     <div
-      class="mt-10 pt-6 border-t border-cream/10 flex flex-col sm:flex-row justify-between items-center gap-2 text-cream/30 text-xs"
+      class="mt-10 pt-6 border-t border-cream/10 flex flex-col sm:flex-row sm:justify-between items-center gap-2 text-cream/30 text-xs"
     >
-      <p>© {currentYear} {personalInfo.name}. All rights reserved.</p>
-      <p>Built with Astro + Tailwind.</p>
+      <p class="order-1">© {currentYear} {personalInfo.name}. All rights reserved.</p>
+
+      <button
+        type="button"
+        class="lights-out-trigger order-2 text-cream/30 hover:text-cream focus-visible:text-cream transition-colors duration-200"
+        aria-label="Open F1 lights-out reaction game"
+        title="ready to race?"
+      >
+        <span aria-hidden="true">🏁</span>
+      </button>
+
+      <p class="order-3">Built with Astro + Tailwind.</p>
     </div>
   </div>
 </footer>
+
+<script>
+  document.querySelectorAll<HTMLButtonElement>('.lights-out-trigger').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      window.dispatchEvent(
+        new CustomEvent('lights-out:open', { detail: { trigger: btn } }),
+      );
+    });
+  });
+</script>

--- a/src/components/lights-out/LightsOut.astro
+++ b/src/components/lights-out/LightsOut.astro
@@ -1,0 +1,287 @@
+---
+// Overlay for the F1 lights-out easter egg.
+// Mounted once globally in BaseLayout.astro. Hidden until the
+// 'lights-out:open' custom event is dispatched on `window`.
+---
+
+<div
+  class="lights-out"
+  data-state="closed"
+  role="dialog"
+  aria-modal="true"
+  aria-label="F1 lights-out reaction game"
+  aria-hidden="true"
+  hidden
+>
+  <!-- Pixel takeover columns are populated by the controller -->
+  <div class="lights-out__pixels" data-pixels></div>
+
+  <!-- Game UI sits above the pixel takeover -->
+  <div class="lights-out__ui">
+    <div class="lights-out__top-bar">
+      <button
+        type="button"
+        class="lights-out__icon-btn"
+        data-sound-toggle
+        aria-label="Toggle sound">🔇</button
+      >
+      <button
+        type="button"
+        class="lights-out__icon-btn"
+        data-close
+        aria-label="Exit game">✕</button
+      >
+    </div>
+
+    <div class="lights-out__gantry" data-gantry>
+      <span class="lights-out__bulb" data-bulb="0"></span>
+      <span class="lights-out__bulb" data-bulb="1"></span>
+      <span class="lights-out__bulb" data-bulb="2"></span>
+      <span class="lights-out__bulb" data-bulb="3"></span>
+      <span class="lights-out__bulb" data-bulb="4"></span>
+    </div>
+
+    <div class="lights-out__message" data-message aria-live="polite">
+      PRESS SPACE OR CLICK TO START
+    </div>
+
+    <div class="lights-out__result" data-result hidden>
+      <div class="lights-out__time" data-time>0 MS</div>
+      <div class="lights-out__best" data-best></div>
+      <div class="lights-out__buttons">
+        <button type="button" class="lights-out__btn" data-race-again
+          >RACE AGAIN</button
+        >
+        <button type="button" class="lights-out__btn" data-exit>EXIT</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  import { mount } from './controller';
+  mount();
+</script>
+
+<style is:global>
+  .lights-out {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    pointer-events: none;
+    font-family: 'Press Start 2P', system-ui, monospace;
+    color: #fefcf6;
+  }
+
+  .lights-out[data-state='open'],
+  .lights-out[data-state='opening'],
+  .lights-out[data-state='closing'] {
+    pointer-events: auto;
+  }
+
+  /* The pixel-block takeover layer */
+  .lights-out__pixels {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+  }
+
+  .lights-out__pixel-col {
+    position: absolute;
+    bottom: 0;
+    width: var(--col-width, 28px);
+    height: var(--col-height, 120vh);
+    background: #000;
+    transform: translateY(100%);
+    transition: transform var(--rise-duration, 1500ms)
+      cubic-bezier(0.4, 0, 0.6, 1) var(--rise-delay, 0ms);
+  }
+
+  .lights-out[data-state='open'] .lights-out__pixel-col,
+  .lights-out[data-state='opening'] .lights-out__pixel-col {
+    transform: translateY(var(--col-rest-offset, 0));
+  }
+
+  /* Subtle scanlines over the takeover */
+  .lights-out__pixels::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.02) 0,
+      rgba(255, 255, 255, 0.02) 1px,
+      transparent 1px,
+      transparent 3px
+    );
+    pointer-events: none;
+  }
+
+  /* UI layer — transparent to clicks except on its actual content,
+     so clicks pass through empty UI areas to the pixel/gap layer below.
+     Without this, the full-bleed UI container would absorb every click. */
+  .lights-out__ui {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2.5rem;
+    opacity: 0;
+    transition: opacity 250ms ease 800ms;
+    pointer-events: none;
+  }
+
+  .lights-out__top-bar,
+  .lights-out__gantry,
+  .lights-out__message,
+  .lights-out__result {
+    pointer-events: auto;
+  }
+
+  .lights-out[data-state='open'] .lights-out__ui {
+    opacity: 1;
+  }
+
+  .lights-out__top-bar {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .lights-out__icon-btn {
+    background: #000;
+    color: #fefcf6;
+    border: 2px solid #fefcf6;
+    width: 44px;
+    height: 44px;
+    font-size: 1.25rem;
+    cursor: pointer;
+    image-rendering: pixelated;
+  }
+
+  .lights-out__icon-btn:focus-visible {
+    outline: 2px solid #ff1f1f;
+    outline-offset: 2px;
+  }
+
+  .lights-out__gantry {
+    display: flex;
+    gap: 1.25rem;
+  }
+
+  .lights-out__bulb {
+    width: 56px;
+    height: 56px;
+    border: 4px solid #2a0606;
+    background: #1a0303;
+    box-shadow: inset 0 0 0 4px #000;
+    image-rendering: pixelated;
+  }
+
+  .lights-out__bulb[data-on='true'] {
+    background: #ff1f1f;
+    border-color: #ff5555;
+    box-shadow:
+      inset 0 0 0 4px #b71010,
+      0 0 24px rgba(255, 31, 31, 0.7);
+  }
+
+  .lights-out__message {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-align: center;
+    padding: 0 1rem;
+  }
+
+  .lights-out__result {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .lights-out__time {
+    font-size: 2.5rem;
+  }
+
+  .lights-out__time[data-new-best='true'] {
+    color: #ff1f1f;
+  }
+
+  .lights-out__best {
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    color: rgba(254, 252, 246, 0.6);
+    min-height: 1em;
+  }
+
+  .lights-out__buttons {
+    display: flex;
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+
+  .lights-out__btn {
+    background: #000;
+    color: #fefcf6;
+    border: 4px solid #fefcf6;
+    padding: 0.75rem 1.25rem;
+    font-family: inherit;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    image-rendering: pixelated;
+  }
+
+  .lights-out__btn:hover,
+  .lights-out__btn:focus-visible {
+    background: #fefcf6;
+    color: #000;
+    outline: none;
+  }
+
+  /* Jump-start flash */
+  .lights-out__pixels[data-jump-start='true']::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 31, 31, 0.45);
+    animation: lights-out-flash 150ms ease-out;
+  }
+
+  @keyframes lights-out-flash {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+
+  /* Reduced motion: snap takeover in instantly */
+  @media (prefers-reduced-motion: reduce) {
+    .lights-out__pixel-col {
+      transition: none !important;
+    }
+    .lights-out__ui {
+      transition: none !important;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .lights-out__bulb {
+      width: 40px;
+      height: 40px;
+    }
+    .lights-out__gantry {
+      gap: 0.75rem;
+    }
+    .lights-out__time {
+      font-size: 1.75rem;
+    }
+  }
+</style>

--- a/src/components/lights-out/LightsOut.astro
+++ b/src/components/lights-out/LightsOut.astro
@@ -190,6 +190,7 @@
   .lights-out__top-bar,
   .lights-out__gantry,
   .lights-out__message,
+  .lights-out__hint,
   .lights-out__result {
     pointer-events: auto;
   }

--- a/src/components/lights-out/LightsOut.astro
+++ b/src/components/lights-out/LightsOut.astro
@@ -153,6 +153,9 @@
   }
 
   .lights-out__icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     background: #000;
     color: #fefcf6;
     border: 2px solid #fefcf6;
@@ -160,7 +163,6 @@
     height: 44px;
     font-size: 1.25rem;
     cursor: pointer;
-    image-rendering: pixelated;
   }
 
   .lights-out__icon-btn:focus-visible {
@@ -234,7 +236,6 @@
     font-size: 0.7rem;
     letter-spacing: 0.08em;
     cursor: pointer;
-    image-rendering: pixelated;
   }
 
   .lights-out__btn:hover,

--- a/src/components/lights-out/LightsOut.astro
+++ b/src/components/lights-out/LightsOut.astro
@@ -79,10 +79,12 @@
     pointer-events: auto;
   }
 
-  /* The pixel-block takeover layer */
+  /* The pixel-block takeover layer.
+     Inset on all sides so the portfolio frames the takeover —
+     plus jagged column heights expose more of it through the top. */
   .lights-out__pixels {
     position: absolute;
-    inset: 0;
+    inset: 7%;
     overflow: hidden;
   }
 
@@ -90,16 +92,15 @@
     position: absolute;
     bottom: 0;
     width: var(--col-width, 28px);
-    height: var(--col-height, 120vh);
+    height: var(--col-height, 100%);
     background: #000;
     transform: translateY(100%);
     transition: transform var(--rise-duration, 1500ms)
       cubic-bezier(0.4, 0, 0.6, 1) var(--rise-delay, 0ms);
   }
 
-  .lights-out[data-state='open'] .lights-out__pixel-col,
-  .lights-out[data-state='opening'] .lights-out__pixel-col {
-    transform: translateY(var(--col-rest-offset, 0));
+  .lights-out[data-state='open'] .lights-out__pixel-col {
+    transform: translateY(0);
   }
 
   /* Subtle scanlines over the takeover */
@@ -129,7 +130,7 @@
     justify-content: center;
     gap: 2.5rem;
     opacity: 0;
-    transition: opacity 250ms ease 800ms;
+    transition: opacity 250ms ease;
     pointer-events: none;
   }
 
@@ -142,6 +143,7 @@
 
   .lights-out[data-state='open'] .lights-out__ui {
     opacity: 1;
+    transition-delay: 800ms;
   }
 
   .lights-out__top-bar {
@@ -161,7 +163,9 @@
     border: 2px solid #fefcf6;
     width: 44px;
     height: 44px;
+    padding: 0;
     font-size: 1.25rem;
+    line-height: 1;
     cursor: pointer;
   }
 

--- a/src/components/lights-out/LightsOut.astro
+++ b/src/components/lights-out/LightsOut.astro
@@ -23,14 +23,54 @@
         type="button"
         class="lights-out__icon-btn"
         data-sound-toggle
-        aria-label="Toggle sound">🔇</button
+        aria-label="Toggle sound"
       >
+        <svg
+          viewBox="0 0 16 16"
+          width="20"
+          height="20"
+          fill="currentColor"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path d="M2 6 H4 L7 3 V13 L4 10 H2 Z"></path>
+          <line
+            x1="9"
+            y1="6"
+            x2="13"
+            y2="10"
+            stroke="currentColor"
+            stroke-width="1.5"></line>
+          <line
+            x1="13"
+            y1="6"
+            x2="9"
+            y2="10"
+            stroke="currentColor"
+            stroke-width="1.5"></line>
+        </svg>
+      </button>
       <button
         type="button"
         class="lights-out__icon-btn"
         data-close
-        aria-label="Exit game">✕</button
+        aria-label="Exit game"
       >
+        <svg
+          viewBox="0 0 16 16"
+          width="20"
+          height="20"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <line x1="4" y1="4" x2="12" y2="12"></line>
+          <line x1="12" y1="4" x2="4" y2="12"></line>
+        </svg>
+      </button>
     </div>
 
     <div class="lights-out__gantry">
@@ -92,7 +132,7 @@
     position: absolute;
     bottom: 0;
     width: var(--col-width, 28px);
-    height: var(--col-height, 100%);
+    height: 100%;
     background: #000;
     transform: translateY(100%);
     transition: transform var(--rise-duration, 1500ms)
@@ -103,7 +143,9 @@
     transform: translateY(0);
   }
 
-  /* Subtle scanlines over the takeover */
+  /* Subtle scanlines over the takeover. Opacity is tied to the open state so
+     they fade out alongside the UI on close, instead of lingering as a
+     "ghost square" after the columns animate away. */
   .lights-out__pixels::after {
     content: '';
     position: absolute;
@@ -116,6 +158,13 @@
       transparent 3px
     );
     pointer-events: none;
+    opacity: 0;
+    transition: opacity 250ms ease;
+  }
+
+  .lights-out[data-state='open'] .lights-out__pixels::after {
+    opacity: 1;
+    transition-delay: 800ms;
   }
 
   /* UI layer — transparent to clicks except on its actual content,

--- a/src/components/lights-out/LightsOut.astro
+++ b/src/components/lights-out/LightsOut.astro
@@ -33,7 +33,7 @@
       >
     </div>
 
-    <div class="lights-out__gantry" data-gantry>
+    <div class="lights-out__gantry">
       <span class="lights-out__bulb" data-bulb="0"></span>
       <span class="lights-out__bulb" data-bulb="1"></span>
       <span class="lights-out__bulb" data-bulb="2"></span>
@@ -250,7 +250,7 @@
     position: absolute;
     inset: 0;
     background: rgba(255, 31, 31, 0.45);
-    animation: lights-out-flash 150ms ease-out;
+    animation: lights-out-flash 150ms ease-out forwards;
   }
 
   @keyframes lights-out-flash {
@@ -269,6 +269,10 @@
     }
     .lights-out__ui {
       transition: none !important;
+    }
+    .lights-out__pixels[data-jump-start='true']::before {
+      animation: none;
+      opacity: 0;
     }
   }
 

--- a/src/components/lights-out/LightsOut.astro
+++ b/src/components/lights-out/LightsOut.astro
@@ -85,6 +85,10 @@
       PRESS SPACE OR CLICK TO START
     </div>
 
+    <div class="lights-out__hint" data-hint>
+      Tap, click, or press SPACE to react · ESC to exit
+    </div>
+
     <div class="lights-out__result" data-result hidden>
       <div class="lights-out__time" data-time>0 MS</div>
       <div class="lights-out__best" data-best></div>
@@ -252,6 +256,16 @@
     padding: 0 1rem;
   }
 
+  .lights-out__hint {
+    font-size: 0.55rem;
+    letter-spacing: 0.06em;
+    text-align: center;
+    padding: 0 1rem;
+    line-height: 1.6;
+    color: rgba(254, 252, 246, 0.5);
+    margin-top: -1.75rem;
+  }
+
   .lights-out__result {
     display: flex;
     flex-direction: column;
@@ -340,6 +354,9 @@
     }
     .lights-out__time {
       font-size: 1.75rem;
+    }
+    .lights-out__hint {
+      font-size: 0.5rem;
     }
   }
 </style>

--- a/src/components/lights-out/__tests__/state.test.ts
+++ b/src/components/lights-out/__tests__/state.test.ts
@@ -77,14 +77,17 @@ describe('lights-out state machine', () => {
     expect(ctx.isNewBest).toBe(true);
   });
 
-  it('result + RACE_AGAIN transitions to arming and clears reactionMs', () => {
-    let ctx = reduce(initialContext({ bestMs: null }), { type: 'INPUT', timestamp: 0 });
+  it('result + RACE_AGAIN transitions to arming, clears transient fields, and preserves bestMs', () => {
+    let ctx = reduce(initialContext({ bestMs: 200 }), { type: 'INPUT', timestamp: 0 });
     ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
     ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
     ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
     ctx = reduce(ctx, { type: 'RACE_AGAIN' });
     expect(ctx.state).toBe('arming');
     expect(ctx.reactionMs).toBe(null);
+    expect(ctx.liveStartTime).toBe(null);
+    expect(ctx.isNewBest).toBe(false);
+    expect(ctx.bestMs).toBe(200);
   });
 
   it('jumpStart + JUMP_START_RECOVERED returns to idle', () => {

--- a/src/components/lights-out/__tests__/state.test.ts
+++ b/src/components/lights-out/__tests__/state.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { initialContext, reduce, type Context } from '../state';
+
+describe('lights-out state machine', () => {
+  const baseCtx: Context = initialContext({ bestMs: null });
+
+  it('starts in idle', () => {
+    expect(baseCtx.state).toBe('idle');
+  });
+
+  it('idle + INPUT transitions to arming', () => {
+    const next = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    expect(next.state).toBe('arming');
+  });
+
+  it('arming + LIGHTS_ARMED transitions to holding', () => {
+    const armed = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    const holding = reduce(armed, { type: 'LIGHTS_ARMED' });
+    expect(holding.state).toBe('holding');
+  });
+
+  it('arming + INPUT transitions to jumpStart', () => {
+    const armed = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    const jumped = reduce(armed, { type: 'INPUT', timestamp: 100 });
+    expect(jumped.state).toBe('jumpStart');
+  });
+
+  it('holding + INPUT transitions to jumpStart', () => {
+    let ctx = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 200 });
+    expect(ctx.state).toBe('jumpStart');
+  });
+
+  it('holding + LIGHTS_OUT transitions to live and stores liveStartTime', () => {
+    let ctx = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 1234 });
+    expect(ctx.state).toBe('live');
+    expect(ctx.liveStartTime).toBe(1234);
+  });
+
+  it('live + INPUT transitions to result and computes reactionMs', () => {
+    let ctx = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 1000 });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 1287 });
+    expect(ctx.state).toBe('result');
+    expect(ctx.reactionMs).toBe(287);
+  });
+
+  it('result with new best updates bestMs and flags isNewBest', () => {
+    let ctx = reduce(initialContext({ bestMs: 500 }), { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
+    expect(ctx.reactionMs).toBe(287);
+    expect(ctx.bestMs).toBe(287);
+    expect(ctx.isNewBest).toBe(true);
+  });
+
+  it('result with non-best keeps existing bestMs and clears isNewBest', () => {
+    let ctx = reduce(initialContext({ bestMs: 200 }), { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
+    expect(ctx.bestMs).toBe(200);
+    expect(ctx.isNewBest).toBe(false);
+  });
+
+  it('result with no prior best treats first time as a new best', () => {
+    let ctx = reduce(initialContext({ bestMs: null }), { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
+    expect(ctx.bestMs).toBe(287);
+    expect(ctx.isNewBest).toBe(true);
+  });
+
+  it('result + RACE_AGAIN transitions to arming and clears reactionMs', () => {
+    let ctx = reduce(initialContext({ bestMs: null }), { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
+    ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
+    ctx = reduce(ctx, { type: 'RACE_AGAIN' });
+    expect(ctx.state).toBe('arming');
+    expect(ctx.reactionMs).toBe(null);
+  });
+
+  it('jumpStart + JUMP_START_RECOVERED returns to idle', () => {
+    let ctx = reduce(baseCtx, { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'INPUT', timestamp: 100 });
+    expect(ctx.state).toBe('jumpStart');
+    ctx = reduce(ctx, { type: 'JUMP_START_RECOVERED' });
+    expect(ctx.state).toBe('idle');
+  });
+
+  it('OPEN resets the context to idle while preserving bestMs', () => {
+    let ctx = reduce(initialContext({ bestMs: 250 }), { type: 'INPUT', timestamp: 0 });
+    ctx = reduce(ctx, { type: 'OPEN' });
+    expect(ctx.state).toBe('idle');
+    expect(ctx.bestMs).toBe(250);
+    expect(ctx.reactionMs).toBe(null);
+    expect(ctx.liveStartTime).toBe(null);
+    expect(ctx.isNewBest).toBe(false);
+  });
+
+  it('ignores irrelevant events without changing state', () => {
+    const next = reduce(baseCtx, { type: 'LIGHTS_OUT', timestamp: 1000 });
+    expect(next).toBe(baseCtx);
+  });
+});

--- a/src/components/lights-out/__tests__/state.test.ts
+++ b/src/components/lights-out/__tests__/state.test.ts
@@ -50,7 +50,10 @@ describe('lights-out state machine', () => {
   });
 
   it('result with new best updates bestMs and flags isNewBest', () => {
-    let ctx = reduce(initialContext({ bestMs: 500 }), { type: 'INPUT', timestamp: 0 });
+    let ctx = reduce(initialContext({ bestMs: 500 }), {
+      type: 'INPUT',
+      timestamp: 0,
+    });
     ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
     ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
     ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
@@ -60,7 +63,10 @@ describe('lights-out state machine', () => {
   });
 
   it('result with non-best keeps existing bestMs and clears isNewBest', () => {
-    let ctx = reduce(initialContext({ bestMs: 200 }), { type: 'INPUT', timestamp: 0 });
+    let ctx = reduce(initialContext({ bestMs: 200 }), {
+      type: 'INPUT',
+      timestamp: 0,
+    });
     ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
     ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
     ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
@@ -69,7 +75,10 @@ describe('lights-out state machine', () => {
   });
 
   it('result with no prior best treats first time as a new best', () => {
-    let ctx = reduce(initialContext({ bestMs: null }), { type: 'INPUT', timestamp: 0 });
+    let ctx = reduce(initialContext({ bestMs: null }), {
+      type: 'INPUT',
+      timestamp: 0,
+    });
     ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
     ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
     ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
@@ -78,7 +87,10 @@ describe('lights-out state machine', () => {
   });
 
   it('result + RACE_AGAIN transitions to arming, clears transient fields, and preserves bestMs', () => {
-    let ctx = reduce(initialContext({ bestMs: 200 }), { type: 'INPUT', timestamp: 0 });
+    let ctx = reduce(initialContext({ bestMs: 200 }), {
+      type: 'INPUT',
+      timestamp: 0,
+    });
     ctx = reduce(ctx, { type: 'LIGHTS_ARMED' });
     ctx = reduce(ctx, { type: 'LIGHTS_OUT', timestamp: 0 });
     ctx = reduce(ctx, { type: 'INPUT', timestamp: 287 });
@@ -99,7 +111,10 @@ describe('lights-out state machine', () => {
   });
 
   it('OPEN resets the context to idle while preserving bestMs', () => {
-    let ctx = reduce(initialContext({ bestMs: 250 }), { type: 'INPUT', timestamp: 0 });
+    let ctx = reduce(initialContext({ bestMs: 250 }), {
+      type: 'INPUT',
+      timestamp: 0,
+    });
     ctx = reduce(ctx, { type: 'OPEN' });
     expect(ctx.state).toBe('idle');
     expect(ctx.bestMs).toBe(250);

--- a/src/components/lights-out/__tests__/storage.test.ts
+++ b/src/components/lights-out/__tests__/storage.test.ts
@@ -35,6 +35,16 @@ describe('lights-out storage', () => {
       writeBestMs(241);
       expect(readBestMs()).toBe(241);
     });
+
+    it('writeBestMs ignores negative input', () => {
+      writeBestMs(-1);
+      expect(readBestMs()).toBe(null);
+    });
+
+    it('writeBestMs ignores non-finite input', () => {
+      writeBestMs(Infinity);
+      expect(readBestMs()).toBe(null);
+    });
   });
 
   describe('soundEnabled', () => {

--- a/src/components/lights-out/__tests__/storage.test.ts
+++ b/src/components/lights-out/__tests__/storage.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { readBestMs, writeBestMs, readSoundEnabled, writeSoundEnabled } from '../storage';
+import {
+  readBestMs,
+  writeBestMs,
+  readSoundEnabled,
+  writeSoundEnabled,
+} from '../storage';
 
 describe('lights-out storage', () => {
   beforeEach(() => {

--- a/src/components/lights-out/__tests__/storage.test.ts
+++ b/src/components/lights-out/__tests__/storage.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readBestMs, writeBestMs, readSoundEnabled, writeSoundEnabled } from '../storage';
+
+describe('lights-out storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('bestMs', () => {
+    it('returns null when key is missing', () => {
+      expect(readBestMs()).toBe(null);
+    });
+
+    it('returns null for non-numeric values', () => {
+      localStorage.setItem('lightsOut.bestMs', 'not-a-number');
+      expect(readBestMs()).toBe(null);
+    });
+
+    it('returns null for negative values', () => {
+      localStorage.setItem('lightsOut.bestMs', '-5');
+      expect(readBestMs()).toBe(null);
+    });
+
+    it('returns null for NaN', () => {
+      localStorage.setItem('lightsOut.bestMs', 'NaN');
+      expect(readBestMs()).toBe(null);
+    });
+
+    it('returns the stored number when valid', () => {
+      localStorage.setItem('lightsOut.bestMs', '287');
+      expect(readBestMs()).toBe(287);
+    });
+
+    it('round-trips a written value', () => {
+      writeBestMs(241);
+      expect(readBestMs()).toBe(241);
+    });
+  });
+
+  describe('soundEnabled', () => {
+    it('defaults to false when missing', () => {
+      expect(readSoundEnabled()).toBe(false);
+    });
+
+    it('reads "true" as true', () => {
+      localStorage.setItem('lightsOut.soundEnabled', 'true');
+      expect(readSoundEnabled()).toBe(true);
+    });
+
+    it('reads anything else as false', () => {
+      localStorage.setItem('lightsOut.soundEnabled', 'yes');
+      expect(readSoundEnabled()).toBe(false);
+    });
+
+    it('round-trips a written boolean', () => {
+      writeSoundEnabled(true);
+      expect(readSoundEnabled()).toBe(true);
+      writeSoundEnabled(false);
+      expect(readSoundEnabled()).toBe(false);
+    });
+  });
+});

--- a/src/components/lights-out/controller.ts
+++ b/src/components/lights-out/controller.ts
@@ -230,9 +230,12 @@ function close(rt: Runtime): void {
 
 function buildPixels(rt: Runtime): void {
   rt.refs.pixels.replaceChildren();
-  const colCount = Math.ceil(window.innerWidth / PIXEL_BLOCK_PX) + 1;
+  // Use the pixels container's actual width (which is now inset from the viewport)
+  // so columns fill exactly the takeover area, not the whole window.
+  const containerWidth = rt.refs.pixels.clientWidth;
+  const colCount = Math.ceil(containerWidth / PIXEL_BLOCK_PX) + 1;
   const center = (colCount - 1) / 2;
-  const maxDistance = center;
+  const maxDistance = center || 1;
 
   const frag = document.createDocumentFragment();
   for (let i = 0; i < colCount; i++) {
@@ -241,13 +244,14 @@ function buildPixels(rt: Runtime): void {
     const distance = Math.abs(i - center) / maxDistance; // 0 in middle, 1 at edges
     const delay = Math.round(distance * 600); // 0–600ms
     const duration = Math.round(900 + distance * 600); // 900–1500ms
-    // Vary column rest position by 0-3 blocks so the top edge is visibly jagged
-    // and the portfolio shows through the gaps.
-    const restOffset = -(Math.floor(Math.random() * 4) * PIXEL_BLOCK_PX); // 0, -28, -56, -84 px
+    // Vary column height by 0-3 blocks so the top edge is visibly jagged
+    // and the portfolio shows through the gaps above shorter columns.
+    const heightShortageBlocks = Math.floor(Math.random() * 4);
+    const heightShortagePx = heightShortageBlocks * PIXEL_BLOCK_PX;
     col.style.setProperty('--col-width', `${PIXEL_BLOCK_PX}px`);
+    col.style.setProperty('--col-height', `calc(100% - ${heightShortagePx}px)`);
     col.style.setProperty('--rise-delay', `${delay}ms`);
     col.style.setProperty('--rise-duration', `${duration}ms`);
-    col.style.setProperty('--col-rest-offset', `${restOffset}px`);
     col.style.left = `${i * PIXEL_BLOCK_PX}px`;
     frag.appendChild(col);
   }

--- a/src/components/lights-out/controller.ts
+++ b/src/components/lights-out/controller.ts
@@ -23,6 +23,7 @@ type Refs = {
   pixels: HTMLElement;
   bulbs: HTMLElement[];
   message: HTMLElement;
+  hint: HTMLElement;
   result: HTMLElement;
   time: HTMLElement;
   best: HTMLElement;
@@ -90,6 +91,7 @@ function collectRefs(root: HTMLElement): Refs {
     pixels: q('[data-pixels]'),
     bulbs,
     message: q('[data-message]'),
+    hint: q('[data-hint]'),
     result: q('[data-result]'),
     time: q('[data-time]'),
     best: q('[data-best]'),
@@ -309,12 +311,15 @@ function applyState(rt: Runtime): void {
       refs.bulbs.forEach((b) => (b.dataset.on = 'false'));
       refs.message.textContent = 'PRESS SPACE OR CLICK TO START';
       refs.message.hidden = false;
+      refs.hint.hidden = false;
       refs.result.hidden = true;
       refs.pixels.dataset.jumpStart = 'false';
       break;
 
     case 'arming':
       refs.message.textContent = 'GET READY';
+      refs.message.hidden = false;
+      refs.hint.hidden = false;
       refs.result.hidden = true;
       refs.time.textContent = '0 MS';
       refs.time.dataset.newBest = 'false';
@@ -383,6 +388,7 @@ function showResult(rt: Runtime): void {
   if (ctx.reactionMs === null) return;
 
   refs.message.hidden = true;
+  refs.hint.hidden = true;
   refs.result.hidden = false;
   refs.time.textContent = `${Math.round(ctx.reactionMs)} MS`;
   refs.time.dataset.newBest = ctx.isNewBest ? 'true' : 'false';

--- a/src/components/lights-out/controller.ts
+++ b/src/components/lights-out/controller.ts
@@ -1,5 +1,10 @@
 import { initialContext, reduce, type Context, type GameEvent } from './state';
-import { readBestMs, writeBestMs, readSoundEnabled, writeSoundEnabled } from './storage';
+import {
+  readBestMs,
+  writeBestMs,
+  readSoundEnabled,
+  writeSoundEnabled,
+} from './storage';
 import { playLightOn, playLightsOut, resumeAudio } from './sound';
 
 const PIXEL_BLOCK_PX = 28;
@@ -93,7 +98,8 @@ function collectRefs(root: HTMLElement): Refs {
 
 function attachListeners(rt: Runtime): void {
   window.addEventListener('lights-out:open', (event) => {
-    const trigger = (event as CustomEvent<{ trigger?: HTMLElement }>).detail?.trigger ?? null;
+    const trigger =
+      (event as CustomEvent<{ trigger?: HTMLElement }>).detail?.trigger ?? null;
     open(rt, trigger);
   });
 
@@ -194,7 +200,10 @@ function open(rt: Runtime, trigger: HTMLElement | null): void {
 function close(rt: Runtime): void {
   // Re-entry guard: if a close is already in flight, ignore subsequent calls.
   // Without this, a click during the 650ms close transition can compound timers and animations.
-  if (rt.refs.root.dataset.state === 'closing' || rt.refs.root.dataset.state === 'closed') {
+  if (
+    rt.refs.root.dataset.state === 'closing' ||
+    rt.refs.root.dataset.state === 'closed'
+  ) {
     return;
   }
   clearAllTimers(rt);

--- a/src/components/lights-out/controller.ts
+++ b/src/components/lights-out/controller.ts
@@ -1,0 +1,346 @@
+import { initialContext, reduce, type Context, type GameEvent } from './state';
+import { readBestMs, writeBestMs, readSoundEnabled, writeSoundEnabled } from './storage';
+import { playLightOn, playLightsOut, resumeAudio } from './sound';
+
+const PIXEL_BLOCK_PX = 28;
+const LIGHT_INTERVAL_MS = 1000;
+const HOLD_MIN_MS = 200;
+const HOLD_MAX_MS = 3000;
+const JUMP_START_COOLDOWN_MS = 2000;
+const NUM_LIGHTS = 5;
+
+type Refs = {
+  root: HTMLElement;
+  pixels: HTMLElement;
+  bulbs: HTMLElement[];
+  message: HTMLElement;
+  result: HTMLElement;
+  time: HTMLElement;
+  best: HTMLElement;
+  raceAgain: HTMLButtonElement;
+  exit: HTMLButtonElement;
+  closeBtn: HTMLButtonElement;
+  soundToggle: HTMLButtonElement;
+};
+
+type Runtime = {
+  refs: Refs;
+  ctx: Context;
+  soundEnabled: boolean;
+  triggerEl: HTMLElement | null;
+  // Pending timers — must be cleared on close to avoid leaks.
+  armingTimers: number[];
+  holdTimer: number | null;
+  jumpStartTimer: number | null;
+};
+
+let runtime: Runtime | null = null;
+
+export function mount(): void {
+  if (runtime) return;
+  if (typeof document === 'undefined') return;
+
+  const root = document.querySelector<HTMLElement>('.lights-out');
+  if (!root) return;
+
+  const refs = collectRefs(root);
+  const soundEnabled = readSoundEnabled();
+  refs.soundToggle.textContent = soundEnabled ? '🔊' : '🔇';
+
+  runtime = {
+    refs,
+    ctx: initialContext({ bestMs: readBestMs() }),
+    soundEnabled,
+    triggerEl: null,
+    armingTimers: [],
+    holdTimer: null,
+    jumpStartTimer: null,
+  };
+
+  attachListeners(runtime);
+}
+
+function collectRefs(root: HTMLElement): Refs {
+  const q = <T extends HTMLElement = HTMLElement>(sel: string): T => {
+    const el = root.querySelector<T>(sel);
+    if (!el) throw new Error(`lights-out: missing element ${sel}`);
+    return el;
+  };
+
+  const bulbs: HTMLElement[] = [];
+  for (let i = 0; i < NUM_LIGHTS; i++) {
+    bulbs.push(q<HTMLElement>(`[data-bulb="${i}"]`));
+  }
+
+  return {
+    root,
+    pixels: q('[data-pixels]'),
+    bulbs,
+    message: q('[data-message]'),
+    result: q('[data-result]'),
+    time: q('[data-time]'),
+    best: q('[data-best]'),
+    raceAgain: q<HTMLButtonElement>('[data-race-again]'),
+    exit: q<HTMLButtonElement>('[data-exit]'),
+    closeBtn: q<HTMLButtonElement>('[data-close]'),
+    soundToggle: q<HTMLButtonElement>('[data-sound-toggle]'),
+  };
+}
+
+function attachListeners(rt: Runtime): void {
+  window.addEventListener('lights-out:open', (event) => {
+    const trigger = (event as CustomEvent<{ trigger?: HTMLElement }>).detail?.trigger ?? null;
+    open(rt, trigger);
+  });
+
+  rt.refs.closeBtn.addEventListener('click', () => close(rt));
+  rt.refs.exit.addEventListener('click', () => close(rt));
+  rt.refs.raceAgain.addEventListener('click', () => {
+    dispatch(rt, { type: 'RACE_AGAIN' });
+  });
+
+  rt.refs.soundToggle.addEventListener('click', () => {
+    rt.soundEnabled = !rt.soundEnabled;
+    writeSoundEnabled(rt.soundEnabled);
+    rt.refs.soundToggle.textContent = rt.soundEnabled ? '🔊' : '🔇';
+    if (rt.soundEnabled) resumeAudio();
+  });
+
+  rt.refs.root.addEventListener('click', (e) => {
+    if (!(e.target instanceof HTMLElement)) return;
+    if (e.target.closest('button')) return; // buttons handle themselves
+
+    // Click landed on a black pixel column or a UI content area = game input.
+    if (
+      e.target.closest('.lights-out__pixel-col') ||
+      e.target.closest('.lights-out__gantry') ||
+      e.target.closest('.lights-out__message') ||
+      e.target.closest('.lights-out__result')
+    ) {
+      dispatch(rt, { type: 'INPUT', timestamp: performance.now() });
+      return;
+    }
+
+    // Anything else — i.e. the transparent gaps in `.lights-out__pixels`
+    // where the portfolio shows through — counts as exit.
+    close(rt);
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (rt.refs.root.dataset.state !== 'open') return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close(rt);
+      return;
+    }
+    if (e.key === 'Tab') {
+      const focusable = getFocusable(rt);
+      if (focusable.length === 0) return;
+      e.preventDefault();
+      const current = document.activeElement;
+      const idx = focusable.indexOf(current as HTMLElement);
+      const next = e.shiftKey
+        ? focusable[idx <= 0 ? focusable.length - 1 : idx - 1]
+        : focusable[idx === -1 || idx === focusable.length - 1 ? 0 : idx + 1];
+      next.focus();
+      return;
+    }
+    if (e.key === ' ' || e.code === 'Space') {
+      e.preventDefault();
+      dispatch(rt, { type: 'INPUT', timestamp: performance.now() });
+    }
+  });
+}
+
+function getFocusable(rt: Runtime): HTMLElement[] {
+  // Returns the overlay's currently visible interactive elements, in tab order.
+  // `offsetParent === null` means the element (or an ancestor) is hidden,
+  // which correctly excludes RACE AGAIN / EXIT while the result panel is hidden.
+  const candidates: HTMLElement[] = [
+    rt.refs.soundToggle,
+    rt.refs.closeBtn,
+    rt.refs.raceAgain,
+    rt.refs.exit,
+  ];
+  return candidates.filter((el) => el.offsetParent !== null);
+}
+
+function open(rt: Runtime, trigger: HTMLElement | null): void {
+  rt.triggerEl = trigger;
+  rt.refs.root.hidden = false;
+  rt.refs.root.setAttribute('aria-hidden', 'false');
+  document.body.style.overflow = 'hidden';
+
+  buildPixels(rt);
+  rt.refs.root.dataset.state = 'opening';
+  // Force a reflow so the transition runs from the initial position.
+  void rt.refs.root.offsetWidth;
+  rt.refs.root.dataset.state = 'open';
+
+  dispatch(rt, { type: 'OPEN' });
+
+  // Move focus into the overlay (close button is a safe initial target).
+  setTimeout(() => rt.refs.closeBtn.focus(), 50);
+}
+
+function close(rt: Runtime): void {
+  clearAllTimers(rt);
+  rt.refs.root.dataset.state = 'closing';
+
+  // Reverse animation: pixels slide back down by clearing the rest offset.
+  for (const col of Array.from(rt.refs.pixels.children) as HTMLElement[]) {
+    col.style.setProperty('--rise-duration', '600ms');
+    col.style.setProperty('--rise-delay', '0ms');
+  }
+  // Force reflow then remove the open data-state to trigger transition.
+  void rt.refs.root.offsetWidth;
+  rt.refs.root.dataset.state = 'closed';
+
+  setTimeout(() => {
+    rt.refs.root.hidden = true;
+    rt.refs.root.setAttribute('aria-hidden', 'true');
+    rt.refs.pixels.replaceChildren();
+    document.body.style.overflow = '';
+    if (rt.triggerEl) rt.triggerEl.focus();
+  }, 650);
+}
+
+function buildPixels(rt: Runtime): void {
+  rt.refs.pixels.replaceChildren();
+  const colCount = Math.ceil(window.innerWidth / PIXEL_BLOCK_PX) + 1;
+  const center = (colCount - 1) / 2;
+  const maxDistance = center;
+
+  const frag = document.createDocumentFragment();
+  for (let i = 0; i < colCount; i++) {
+    const col = document.createElement('div');
+    col.className = 'lights-out__pixel-col';
+    const distance = Math.abs(i - center) / maxDistance; // 0 in middle, 1 at edges
+    const delay = Math.round(distance * 600); // 0–600ms
+    const duration = Math.round(900 + distance * 600); // 900–1500ms
+    const restOffset = -(Math.floor(Math.random() * 4) * 6); // 0, -6, -12, -18 px
+    col.style.setProperty('--col-width', `${PIXEL_BLOCK_PX}px`);
+    col.style.setProperty('--rise-delay', `${delay}ms`);
+    col.style.setProperty('--rise-duration', `${duration}ms`);
+    col.style.setProperty('--col-rest-offset', `${restOffset}px`);
+    col.style.left = `${i * PIXEL_BLOCK_PX}px`;
+    frag.appendChild(col);
+  }
+  rt.refs.pixels.appendChild(frag);
+}
+
+function dispatch(rt: Runtime, event: GameEvent): void {
+  const prev = rt.ctx;
+  rt.ctx = reduce(rt.ctx, event);
+  if (rt.ctx === prev) return;
+  applyState(rt);
+}
+
+function applyState(rt: Runtime): void {
+  const { ctx, refs } = rt;
+
+  switch (ctx.state) {
+    case 'idle':
+      clearAllTimers(rt);
+      refs.bulbs.forEach((b) => (b.dataset.on = 'false'));
+      refs.message.textContent = 'PRESS SPACE OR CLICK TO START';
+      refs.message.hidden = false;
+      refs.result.hidden = true;
+      refs.pixels.dataset.jumpStart = 'false';
+      break;
+
+    case 'arming':
+      refs.message.textContent = 'GET READY';
+      refs.result.hidden = true;
+      refs.bulbs.forEach((b) => (b.dataset.on = 'false'));
+      runArming(rt);
+      break;
+
+    case 'holding':
+      runHolding(rt);
+      break;
+
+    case 'live':
+      // All lights extinguish; visual handled in runHolding's lights-out callback.
+      refs.message.textContent = 'GO!';
+      break;
+
+    case 'result':
+      showResult(rt);
+      break;
+
+    case 'jumpStart':
+      refs.pixels.dataset.jumpStart = 'true';
+      refs.bulbs.forEach((b) => (b.dataset.on = 'false'));
+      refs.message.textContent = '🚨 JUMP START 🚨';
+      refs.result.hidden = true;
+      clearAllTimers(rt);
+      rt.jumpStartTimer = window.setTimeout(() => {
+        refs.pixels.dataset.jumpStart = 'false';
+        dispatch(rt, { type: 'JUMP_START_RECOVERED' });
+      }, JUMP_START_COOLDOWN_MS);
+      break;
+  }
+}
+
+function runArming(rt: Runtime): void {
+  clearAllTimers(rt);
+  for (let i = 0; i < NUM_LIGHTS; i++) {
+    const t = window.setTimeout(
+      () => {
+        if (rt.ctx.state !== 'arming') return;
+        rt.refs.bulbs[i].dataset.on = 'true';
+        if (rt.soundEnabled) playLightOn();
+        if (i === NUM_LIGHTS - 1) {
+          dispatch(rt, { type: 'LIGHTS_ARMED' });
+        }
+      },
+      LIGHT_INTERVAL_MS * (i + 1),
+    );
+    rt.armingTimers.push(t);
+  }
+}
+
+function runHolding(rt: Runtime): void {
+  const delay = HOLD_MIN_MS + Math.random() * (HOLD_MAX_MS - HOLD_MIN_MS);
+  rt.holdTimer = window.setTimeout(() => {
+    if (rt.ctx.state !== 'holding') return;
+    rt.refs.bulbs.forEach((b) => (b.dataset.on = 'false'));
+    if (rt.soundEnabled) playLightsOut();
+    dispatch(rt, { type: 'LIGHTS_OUT', timestamp: performance.now() });
+  }, delay);
+}
+
+function showResult(rt: Runtime): void {
+  const { ctx, refs } = rt;
+  if (ctx.reactionMs === null) return;
+
+  refs.message.hidden = true;
+  refs.result.hidden = false;
+  refs.time.textContent = `${Math.round(ctx.reactionMs)} MS`;
+  refs.time.dataset.newBest = ctx.isNewBest ? 'true' : 'false';
+
+  if (ctx.isNewBest) {
+    refs.best.textContent = 'NEW PERSONAL BEST!';
+    if (ctx.bestMs !== null) writeBestMs(Math.round(ctx.bestMs));
+  } else if (ctx.bestMs !== null) {
+    refs.best.textContent = `BEST: ${Math.round(ctx.bestMs)} MS`;
+  } else {
+    refs.best.textContent = '';
+  }
+
+  refs.raceAgain.focus();
+}
+
+function clearAllTimers(rt: Runtime): void {
+  rt.armingTimers.forEach((t) => clearTimeout(t));
+  rt.armingTimers = [];
+  if (rt.holdTimer !== null) {
+    clearTimeout(rt.holdTimer);
+    rt.holdTimer = null;
+  }
+  if (rt.jumpStartTimer !== null) {
+    clearTimeout(rt.jumpStartTimer);
+    rt.jumpStartTimer = null;
+  }
+}

--- a/src/components/lights-out/controller.ts
+++ b/src/components/lights-out/controller.ts
@@ -14,6 +14,10 @@ const HOLD_MAX_MS = 3000;
 const JUMP_START_COOLDOWN_MS = 2000;
 const NUM_LIGHTS = 5;
 
+const SOUND_ON_SVG = `<svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true" focusable="false"><path d="M2 6 H4 L7 3 V13 L4 10 H2 Z" /><path d="M9 5 Q11 8 9 11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" /><path d="M11 3 Q14 8 11 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" /></svg>`;
+
+const SOUND_OFF_SVG = `<svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true" focusable="false"><path d="M2 6 H4 L7 3 V13 L4 10 H2 Z" /><line x1="9" y1="6" x2="13" y2="10" stroke="currentColor" stroke-width="1.5" /><line x1="13" y1="6" x2="9" y2="10" stroke="currentColor" stroke-width="1.5" /></svg>`;
+
 type Refs = {
   root: HTMLElement;
   pixels: HTMLElement;
@@ -52,7 +56,7 @@ export function mount(): void {
 
   const refs = collectRefs(root);
   const soundEnabled = readSoundEnabled();
-  refs.soundToggle.textContent = soundEnabled ? '🔊' : '🔇';
+  refs.soundToggle.innerHTML = soundEnabled ? SOUND_ON_SVG : SOUND_OFF_SVG;
 
   runtime = {
     refs,
@@ -112,7 +116,9 @@ function attachListeners(rt: Runtime): void {
   rt.refs.soundToggle.addEventListener('click', () => {
     rt.soundEnabled = !rt.soundEnabled;
     writeSoundEnabled(rt.soundEnabled);
-    rt.refs.soundToggle.textContent = rt.soundEnabled ? '🔊' : '🔇';
+    rt.refs.soundToggle.innerHTML = rt.soundEnabled
+      ? SOUND_ON_SVG
+      : SOUND_OFF_SVG;
     if (rt.soundEnabled) resumeAudio();
   });
 
@@ -223,6 +229,7 @@ function close(rt: Runtime): void {
     rt.refs.root.hidden = true;
     rt.refs.root.setAttribute('aria-hidden', 'true');
     rt.refs.pixels.replaceChildren();
+    rt.refs.pixels.style.clipPath = '';
     document.body.style.overflow = '';
     if (rt.triggerEl) rt.triggerEl.focus();
   }, 650);
@@ -230,9 +237,16 @@ function close(rt: Runtime): void {
 
 function buildPixels(rt: Runtime): void {
   rt.refs.pixels.replaceChildren();
-  // Use the pixels container's actual width (which is now inset from the viewport)
+  // Use the pixels container's actual dimensions (which is now inset from the viewport)
   // so columns fill exactly the takeover area, not the whole window.
   const containerWidth = rt.refs.pixels.clientWidth;
+  const containerHeight = rt.refs.pixels.clientHeight;
+
+  rt.refs.pixels.style.clipPath = buildJaggedClipPath(
+    containerWidth,
+    containerHeight,
+  );
+
   const colCount = Math.ceil(containerWidth / PIXEL_BLOCK_PX) + 1;
   const center = (colCount - 1) / 2;
   const maxDistance = center || 1;
@@ -244,18 +258,39 @@ function buildPixels(rt: Runtime): void {
     const distance = Math.abs(i - center) / maxDistance; // 0 in middle, 1 at edges
     const delay = Math.round(distance * 600); // 0–600ms
     const duration = Math.round(900 + distance * 600); // 900–1500ms
-    // Vary column height by 0-3 blocks so the top edge is visibly jagged
-    // and the portfolio shows through the gaps above shorter columns.
-    const heightShortageBlocks = Math.floor(Math.random() * 4);
-    const heightShortagePx = heightShortageBlocks * PIXEL_BLOCK_PX;
     col.style.setProperty('--col-width', `${PIXEL_BLOCK_PX}px`);
-    col.style.setProperty('--col-height', `calc(100% - ${heightShortagePx}px)`);
     col.style.setProperty('--rise-delay', `${delay}ms`);
     col.style.setProperty('--rise-duration', `${duration}ms`);
     col.style.left = `${i * PIXEL_BLOCK_PX}px`;
     frag.appendChild(col);
   }
   rt.refs.pixels.appendChild(frag);
+}
+
+function buildJaggedClipPath(width: number, height: number): string {
+  const step = PIXEL_BLOCK_PX;
+  const points: string[] = [];
+  const jitter = (max: number): number =>
+    Math.floor(Math.random() * (max + 1)) * step;
+
+  // Top edge: left → right (inward jitter pushes the edge DOWN)
+  for (let x = 0; x <= width; x += step) {
+    points.push(`${x}px ${jitter(3)}px`);
+  }
+  // Right edge: top → bottom (inward jitter pushes the edge LEFT)
+  for (let y = step; y < height; y += step) {
+    points.push(`${width - jitter(2)}px ${y}px`);
+  }
+  // Bottom edge: right → left (inward jitter pushes the edge UP)
+  for (let x = width; x >= 0; x -= step) {
+    points.push(`${x}px ${height - jitter(2)}px`);
+  }
+  // Left edge: bottom → top (inward jitter pushes the edge RIGHT)
+  for (let y = height - step; y > 0; y -= step) {
+    points.push(`${jitter(2)}px ${y}px`);
+  }
+
+  return `polygon(${points.join(', ')})`;
 }
 
 function dispatch(rt: Runtime, event: GameEvent): void {

--- a/src/components/lights-out/controller.ts
+++ b/src/components/lights-out/controller.ts
@@ -182,8 +182,8 @@ function open(rt: Runtime, trigger: HTMLElement | null): void {
   document.body.style.overflow = 'hidden';
 
   buildPixels(rt);
-  rt.refs.root.dataset.state = 'opening';
-  // Force a reflow so the transition runs from the initial position.
+  // Force the browser to compute the initial 'closed' state before we change to 'open',
+  // so the column transition runs from translateY(100%) to the rest position.
   void rt.refs.root.offsetWidth;
   rt.refs.root.dataset.state = 'open';
 
@@ -241,7 +241,9 @@ function buildPixels(rt: Runtime): void {
     const distance = Math.abs(i - center) / maxDistance; // 0 in middle, 1 at edges
     const delay = Math.round(distance * 600); // 0–600ms
     const duration = Math.round(900 + distance * 600); // 900–1500ms
-    const restOffset = -(Math.floor(Math.random() * 4) * 6); // 0, -6, -12, -18 px
+    // Vary column rest position by 0-3 blocks so the top edge is visibly jagged
+    // and the portfolio shows through the gaps.
+    const restOffset = -(Math.floor(Math.random() * 4) * PIXEL_BLOCK_PX); // 0, -28, -56, -84 px
     col.style.setProperty('--col-width', `${PIXEL_BLOCK_PX}px`);
     col.style.setProperty('--rise-delay', `${delay}ms`);
     col.style.setProperty('--rise-duration', `${duration}ms`);
@@ -275,6 +277,9 @@ function applyState(rt: Runtime): void {
     case 'arming':
       refs.message.textContent = 'GET READY';
       refs.result.hidden = true;
+      refs.time.textContent = '0 MS';
+      refs.time.dataset.newBest = 'false';
+      refs.best.textContent = '';
       refs.bulbs.forEach((b) => (b.dataset.on = 'false'));
       runArming(rt);
       break;

--- a/src/components/lights-out/controller.ts
+++ b/src/components/lights-out/controller.ts
@@ -133,6 +133,7 @@ function attachListeners(rt: Runtime): void {
       e.target.closest('.lights-out__pixel-col') ||
       e.target.closest('.lights-out__gantry') ||
       e.target.closest('.lights-out__message') ||
+      e.target.closest('.lights-out__hint') ||
       e.target.closest('.lights-out__result')
     ) {
       dispatch(rt, { type: 'INPUT', timestamp: performance.now() });

--- a/src/components/lights-out/controller.ts
+++ b/src/components/lights-out/controller.ts
@@ -32,6 +32,8 @@ type Runtime = {
   armingTimers: number[];
   holdTimer: number | null;
   jumpStartTimer: number | null;
+  focusTimer: number | null;
+  cleanupTimer: number | null;
 };
 
 let runtime: Runtime | null = null;
@@ -55,6 +57,8 @@ export function mount(): void {
     armingTimers: [],
     holdTimer: null,
     jumpStartTimer: null,
+    focusTimer: null,
+    cleanupTimer: null,
   };
 
   attachListeners(runtime);
@@ -180,10 +184,19 @@ function open(rt: Runtime, trigger: HTMLElement | null): void {
   dispatch(rt, { type: 'OPEN' });
 
   // Move focus into the overlay (close button is a safe initial target).
-  setTimeout(() => rt.refs.closeBtn.focus(), 50);
+  // Tracked on runtime so close() can cancel it if the user closes within 50ms.
+  rt.focusTimer = window.setTimeout(() => {
+    rt.focusTimer = null;
+    rt.refs.closeBtn.focus();
+  }, 50);
 }
 
 function close(rt: Runtime): void {
+  // Re-entry guard: if a close is already in flight, ignore subsequent calls.
+  // Without this, a click during the 650ms close transition can compound timers and animations.
+  if (rt.refs.root.dataset.state === 'closing' || rt.refs.root.dataset.state === 'closed') {
+    return;
+  }
   clearAllTimers(rt);
   rt.refs.root.dataset.state = 'closing';
 
@@ -196,7 +209,8 @@ function close(rt: Runtime): void {
   void rt.refs.root.offsetWidth;
   rt.refs.root.dataset.state = 'closed';
 
-  setTimeout(() => {
+  rt.cleanupTimer = window.setTimeout(() => {
+    rt.cleanupTimer = null;
     rt.refs.root.hidden = true;
     rt.refs.root.setAttribute('aria-hidden', 'true');
     rt.refs.pixels.replaceChildren();
@@ -342,5 +356,13 @@ function clearAllTimers(rt: Runtime): void {
   if (rt.jumpStartTimer !== null) {
     clearTimeout(rt.jumpStartTimer);
     rt.jumpStartTimer = null;
+  }
+  if (rt.focusTimer !== null) {
+    clearTimeout(rt.focusTimer);
+    rt.focusTimer = null;
+  }
+  if (rt.cleanupTimer !== null) {
+    clearTimeout(rt.cleanupTimer);
+    rt.cleanupTimer = null;
   }
 }

--- a/src/components/lights-out/sound.ts
+++ b/src/components/lights-out/sound.ts
@@ -3,7 +3,10 @@ let ctx: AudioContext | null = null;
 function getContext(): AudioContext | null {
   if (ctx) return ctx;
   try {
-    const Ctor = window.AudioContext ?? (window as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    const Ctor =
+      window.AudioContext ??
+      (window as { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext;
     if (!Ctor) return null;
     ctx = new Ctor();
     return ctx;

--- a/src/components/lights-out/sound.ts
+++ b/src/components/lights-out/sound.ts
@@ -1,0 +1,51 @@
+let ctx: AudioContext | null = null;
+
+function getContext(): AudioContext | null {
+  if (ctx) return ctx;
+  try {
+    const Ctor = window.AudioContext ?? (window as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctor) return null;
+    ctx = new Ctor();
+    return ctx;
+  } catch {
+    return null;
+  }
+}
+
+function playTone(frequency: number, durationMs: number): void {
+  const audio = getContext();
+  if (!audio) return;
+
+  const osc = audio.createOscillator();
+  const gain = audio.createGain();
+  osc.type = 'square';
+  osc.frequency.setValueAtTime(frequency, audio.currentTime);
+
+  // Quick attack/decay envelope to avoid clicks
+  gain.gain.setValueAtTime(0, audio.currentTime);
+  gain.gain.linearRampToValueAtTime(0.18, audio.currentTime + 0.01);
+  gain.gain.linearRampToValueAtTime(0, audio.currentTime + durationMs / 1000);
+
+  osc.connect(gain);
+  gain.connect(audio.destination);
+  osc.start();
+  osc.stop(audio.currentTime + durationMs / 1000);
+}
+
+/** Higher beep played as each light turns on. */
+export function playLightOn(): void {
+  playTone(880, 120);
+}
+
+/** Lower, longer beep played when all lights extinguish. */
+export function playLightsOut(): void {
+  playTone(440, 250);
+}
+
+/** Resume the AudioContext after a user gesture (required by browser autoplay policy). */
+export function resumeAudio(): void {
+  const audio = getContext();
+  if (audio && audio.state === 'suspended') {
+    void audio.resume();
+  }
+}

--- a/src/components/lights-out/state.ts
+++ b/src/components/lights-out/state.ts
@@ -1,0 +1,90 @@
+export type State =
+  | 'idle'
+  | 'arming'
+  | 'holding'
+  | 'live'
+  | 'result'
+  | 'jumpStart';
+
+export type GameEvent =
+  | { type: 'OPEN' }
+  | { type: 'INPUT'; timestamp: number }
+  | { type: 'LIGHTS_ARMED' }
+  | { type: 'LIGHTS_OUT'; timestamp: number }
+  | { type: 'JUMP_START_RECOVERED' }
+  | { type: 'RACE_AGAIN' };
+
+export interface Context {
+  state: State;
+  liveStartTime: number | null;
+  reactionMs: number | null;
+  bestMs: number | null;
+  isNewBest: boolean;
+}
+
+export function initialContext(opts: { bestMs: number | null }): Context {
+  return {
+    state: 'idle',
+    liveStartTime: null,
+    reactionMs: null,
+    bestMs: opts.bestMs,
+    isNewBest: false,
+  };
+}
+
+export function reduce(ctx: Context, event: GameEvent): Context {
+  switch (event.type) {
+    case 'OPEN':
+      return {
+        ...ctx,
+        state: 'idle',
+        liveStartTime: null,
+        reactionMs: null,
+        isNewBest: false,
+      };
+
+    case 'INPUT':
+      if (ctx.state === 'idle') {
+        return { ...ctx, state: 'arming' };
+      }
+      if (ctx.state === 'arming' || ctx.state === 'holding') {
+        return { ...ctx, state: 'jumpStart' };
+      }
+      if (ctx.state === 'live' && ctx.liveStartTime !== null) {
+        const reactionMs = event.timestamp - ctx.liveStartTime;
+        const isNewBest = ctx.bestMs === null || reactionMs < ctx.bestMs;
+        return {
+          ...ctx,
+          state: 'result',
+          reactionMs,
+          isNewBest,
+          bestMs: isNewBest ? reactionMs : ctx.bestMs,
+        };
+      }
+      return ctx;
+
+    case 'LIGHTS_ARMED':
+      if (ctx.state === 'arming') {
+        return { ...ctx, state: 'holding' };
+      }
+      return ctx;
+
+    case 'LIGHTS_OUT':
+      if (ctx.state === 'holding') {
+        return { ...ctx, state: 'live', liveStartTime: event.timestamp };
+      }
+      return ctx;
+
+    case 'JUMP_START_RECOVERED':
+      if (ctx.state === 'jumpStart') {
+        return { ...ctx, state: 'idle' };
+      }
+      return ctx;
+
+    case 'RACE_AGAIN':
+      if (ctx.state === 'result' || ctx.state === 'idle') {
+        return { ...ctx, state: 'arming', reactionMs: null, liveStartTime: null, isNewBest: false };
+      }
+      return ctx;
+  }
+}

--- a/src/components/lights-out/state.ts
+++ b/src/components/lights-out/state.ts
@@ -83,7 +83,13 @@ export function reduce(ctx: Context, event: GameEvent): Context {
 
     case 'RACE_AGAIN':
       if (ctx.state === 'result' || ctx.state === 'idle') {
-        return { ...ctx, state: 'arming', reactionMs: null, liveStartTime: null, isNewBest: false };
+        return {
+          ...ctx,
+          state: 'arming',
+          reactionMs: null,
+          liveStartTime: null,
+          isNewBest: false,
+        };
       }
       return ctx;
   }

--- a/src/components/lights-out/storage.ts
+++ b/src/components/lights-out/storage.ts
@@ -1,0 +1,39 @@
+const KEY_BEST_MS = 'lightsOut.bestMs';
+const KEY_SOUND_ENABLED = 'lightsOut.soundEnabled';
+
+function safeGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // localStorage unavailable or full; ignore.
+  }
+}
+
+export function readBestMs(): number | null {
+  const raw = safeGet(KEY_BEST_MS);
+  if (raw === null) return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
+export function writeBestMs(ms: number): void {
+  if (!Number.isFinite(ms) || ms < 0) return;
+  safeSet(KEY_BEST_MS, String(ms));
+}
+
+export function readSoundEnabled(): boolean {
+  return safeGet(KEY_SOUND_ENABLED) === 'true';
+}
+
+export function writeSoundEnabled(enabled: boolean): void {
+  safeSet(KEY_SOUND_ENABLED, enabled ? 'true' : 'false');
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -41,7 +41,10 @@ class InMemoryStorage implements Storage {
 }
 
 // Only replace if the native implementation is broken (missing .clear).
-if (typeof localStorage === 'undefined' || typeof localStorage.clear !== 'function') {
+if (
+  typeof localStorage === 'undefined' ||
+  typeof localStorage.clear !== 'function'
+) {
   Object.defineProperty(globalThis, 'localStorage', {
     value: new InMemoryStorage(),
     writable: true,

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,50 @@
+/**
+ * Vitest global setup: replace Node 25's stub localStorage with a proper
+ * in-memory implementation so that jsdom tests can call .clear(), .setItem(),
+ * .getItem() etc. without errors.
+ *
+ * Node 25 exposes a built-in `localStorage` (backed by --localstorage-file)
+ * that only partially implements the Web Storage API — .clear() is missing.
+ * This setup file runs before every test file and ensures the global is a
+ * fully-functional in-memory Storage object.
+ */
+
+class InMemoryStorage implements Storage {
+  private store: Record<string, string> = {};
+
+  get length(): number {
+    return Object.keys(this.store).length;
+  }
+
+  clear(): void {
+    this.store = {};
+  }
+
+  getItem(key: string): string | null {
+    return Object.prototype.hasOwnProperty.call(this.store, key)
+      ? this.store[key]
+      : null;
+  }
+
+  key(index: number): string | null {
+    const keys = Object.keys(this.store);
+    return keys[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    delete this.store[key];
+  }
+
+  setItem(key: string, value: string): void {
+    this.store[key] = value;
+  }
+}
+
+// Only replace if the native implementation is broken (missing .clear).
+if (typeof localStorage === 'undefined' || typeof localStorage.clear !== 'function') {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: new InMemoryStorage(),
+    writable: true,
+    configurable: true,
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    environmentOptions: {
+      jsdom: {
+        url: 'http://localhost/',
+      },
+    },
+    setupFiles: ['src/test-setup.ts'],
     include: ['src/**/__tests__/**/*.test.ts'],
     globals: false,
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/__tests__/**/*.test.ts'],
+    globals: false,
+  },
+});


### PR DESCRIPTION
## Summary

A hidden F1 lights-out reaction-time game triggered by a small `🏁` glyph centered in the footer's bottom bar. Clicking the flag triggers a full-screen 8-bit pixel takeover with the iconic 5-light start sequence; React when the lights go out, get your reaction time in milliseconds, with personal-best tracking via `localStorage`.

- **Centered checkered-flag trigger** in the footer (between the copyright and "Built with…" text — its placement is itself the clue)
- **Pixel takeover animation**: black columns rise from the bottom of the viewport, middle columns fastest, edges slower; jagged `clip-path` outline on all four sides so the portfolio frames the takeover like an imperfect modal that broke onto the page
- **Authentic F1 lights-out sequence** with 5 lights illuminating at 1s intervals, a random 200–3000ms hold, then all out — go!
- **Jump-start rule**: any input before the lights go out triggers a red flash, `🚨 JUMP START 🚨`, and a 2s cooldown
- **Personal-best tracking** in localStorage with a `NEW PERSONAL BEST!` flash on improvement
- **Opt-in sound** via Web Audio API (off by default, persisted; iconic chiptune beeps)
- **Click zoning**: clicks on the black takeover or UI = game input; clicks outside = exit; `Esc` exits; spacebar reacts; X button always available
- **Accessibility**: `role="dialog"` + `aria-modal`, focus trap excluding hidden buttons, focus restoration to the trigger on close, `prefers-reduced-motion` snaps the takeover in instantly and suppresses the jump-start flash

## Architecture

- `src/components/lights-out/state.ts` — pure state-machine reducer (idle → arming → holding → live → result, with jumpStart interrupt)
- `src/components/lights-out/storage.ts` — defensive localStorage helpers (try/catch, finite-number validation)
- `src/components/lights-out/sound.ts` — Web Audio tone generator with lazy AudioContext
- `src/components/lights-out/controller.ts` — DOM wiring, rising-pixel animation, click zoning, focus trap, timer hygiene
- `src/components/lights-out/LightsOut.astro` — overlay markup and styles
- Footer dispatches `lights-out:open` via custom event; the overlay listens. Loose coupling means future triggers (Konami code, hidden URL, etc.) can dispatch the same event.
- 26 vitest unit tests covering the state machine and storage helpers
- `vitest@^2.1.0` + `jsdom@^25.0.0` added as dev deps; `npm test` / `npm run test:watch` scripts wired in

## Process

Built via the superpowers brainstorm → spec → plan → execute workflow. Spec at `docs/superpowers/specs/2026-05-02-f1-lights-out-easter-egg-design.md` and plan at `docs/superpowers/plans/2026-05-02-f1-lights-out-easter-egg.md`. Each task was implemented and reviewed in isolation; user manual-tested at the end and several iterative polish fixes were applied (icon centering via SVG swap, all-sides jagged edges via runtime-generated clip-path polygon, instruction hint, ghost-square scanline fade-out, close-fade timing fix).

## Test plan

- [x] `npm test` — 26/26 pass
- [x] `npm run build` — clean
- [ ] Open dev server, scroll to footer, confirm centered `🏁` between copyright and "Built with…"
- [ ] Click flag → takeover animates from bottom; jagged edges visible on all four sides; portfolio shows through
- [ ] Press space (or click black) → 5 red lights illuminate at 1s intervals
- [ ] React when all lights go out → time displays, best time persists across reloads
- [ ] Try a jump start → red flash, 2s cooldown, return to ready
- [ ] Toggle sound on, play a round → beeps audible; preference persists across reloads
- [ ] Esc / X / RACE AGAIN / EXIT all behave correctly; focus returns to flag on close
- [ ] Mobile (DevTools device emulation) — tap to react works, X button reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)