### PR TITLE
Add Vercel Web Analytics + lights-out event tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.15",
+        "@vercel/analytics": "^2.0.1",
         "astro": "^6.1.6",
         "autoprefixer": "^10.4.20",
         "tailwindcss": "^3.4.17"
@@ -1814,6 +1815,48 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.15",
+    "@vercel/analytics": "^2.0.1",
     "astro": "^6.1.6",
     "autoprefixer": "^10.4.20",
     "tailwindcss": "^3.4.17"

--- a/src/components/layout/BaseLayout.astro
+++ b/src/components/layout/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../../styles/global.css';
+import Analytics from '@vercel/analytics/astro';
 import LightsOut from '../lights-out/LightsOut.astro';
 
 interface Props {
@@ -65,5 +66,6 @@ const {
   <body>
     <slot />
     <LightsOut />
+    <Analytics />
   </body>
 </html>

--- a/src/components/lights-out/controller.ts
+++ b/src/components/lights-out/controller.ts
@@ -1,3 +1,4 @@
+import { track } from '@vercel/analytics';
 import { initialContext, reduce, type Context, type GameEvent } from './state';
 import {
   readBestMs,
@@ -189,6 +190,7 @@ function open(rt: Runtime, trigger: HTMLElement | null): void {
   rt.refs.root.hidden = false;
   rt.refs.root.setAttribute('aria-hidden', 'false');
   document.body.style.overflow = 'hidden';
+  track('lights_out_opened');
 
   buildPixels(rt);
   // Force the browser to compute the initial 'closed' state before we change to 'open',
@@ -347,6 +349,7 @@ function applyState(rt: Runtime): void {
       refs.bulbs.forEach((b) => (b.dataset.on = 'false'));
       refs.message.textContent = '🚨 JUMP START 🚨';
       refs.result.hidden = true;
+      track('lights_out_jump_start');
       clearAllTimers(rt);
       rt.jumpStartTimer = window.setTimeout(() => {
         refs.pixels.dataset.jumpStart = 'false';
@@ -397,12 +400,14 @@ function showResult(rt: Runtime): void {
   if (ctx.isNewBest) {
     refs.best.textContent = 'NEW PERSONAL BEST!';
     if (ctx.bestMs !== null) writeBestMs(Math.round(ctx.bestMs));
+    track('lights_out_new_best', { reactionMs: Math.round(ctx.reactionMs) });
   } else if (ctx.bestMs !== null) {
     refs.best.textContent = `BEST: ${Math.round(ctx.bestMs)} MS`;
   } else {
     refs.best.textContent = '';
   }
 
+  track('lights_out_completed', { reactionMs: Math.round(ctx.reactionMs) });
   refs.raceAgain.focus();
 }
 


### PR DESCRIPTION
## Summary

Wires up free Vercel Web Analytics for pageviews and fires custom events from the lights-out easter egg so we can see whether visitors are actually finding it.

- `<Analytics />` mounted globally in `BaseLayout.astro` — automatic pageview tracking, no cookies, no consent banner needed
- Four custom events from `controller.ts`:
  - `lights_out_opened` — flag clicked
  - `lights_out_jump_start` — false start
  - `lights_out_completed` — round finished (includes `reactionMs`)
  - `lights_out_new_best` — new personal best (includes `reactionMs`)
- New dep: `@vercel/analytics@^2.0.1` — adds ~5KB gzipped
- Free tier covers **2,500 events/month** (plenty for a portfolio); $0 for normal use

## One-time dashboard step

After merging, **enable Web Analytics in the Vercel project dashboard** (Project → Analytics tab → Enable). Without that flip, the script no-ops silently. Events will appear in the dashboard within a few minutes of real traffic.

## Test plan

- [x] `npm test` — 26/26 pass
- [x] `npm run build` — clean
- [ ] Deploy to Vercel preview, enable Analytics, open the site
- [ ] Confirm pageview lands in Vercel Analytics dashboard
- [ ] Click the footer 🏁, finish a round, confirm `lights_out_opened` and `lights_out_completed` events show up
- [ ] Trigger a jump start, confirm `lights_out_jump_start` event
- [ ] Beat your best, confirm `lights_out_new_best` event with `reactionMs` property

🤖 Generated with [Claude Code](https://claude.com/claude-code)