### PR TITLE
Trim Currently into list

### DIFF
--- a/src/components/sections/About.astro
+++ b/src/components/sections/About.astro
@@ -6,12 +6,9 @@ import { personalInfo } from '../../data/personalInfo';
 const interests = [
   'Classical piano & trumpet',
   'Reading',
-  'Running',
-  'Rock climbing',
   'Formula 1',
   'Birdwatching',
   'Language learning (German)',
-  'Meditation',
   'Volunteer: Guardian ad Litem',
   'Wine — WSET Level 2',
 ];


### PR DESCRIPTION
## Summary
- Remove Running, Rock climbing, and Meditation from the About section's *Currently into* list.

## Test plan
- [ ] `npm run dev` → confirm the About section's *Currently into* list renders the remaining 7 items.
- [ ] Dark + light mode both look right (no orphaned dot bullets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)