### PR TITLE
Split Writing into per-platform rows (Engineering + Chart Position)

### DIFF
--- a/src/components/sections/Writing.astro
+++ b/src/components/sections/Writing.astro
@@ -38,6 +38,7 @@ const rows = [
                 href={row.href}
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label={`All posts on ${row.label}`}
                 class="shrink-0 text-sm font-medium text-sage dark:text-sage-light hover:text-ink-dark dark:hover:text-cream transition-colors duration-200 whitespace-nowrap flex items-center gap-1.5"
               >
                 All posts

--- a/src/components/sections/Writing.astro
+++ b/src/components/sections/Writing.astro
@@ -1,65 +1,80 @@
 ---
 import SectionHeading from '../ui/SectionHeading.astro';
 import PostCard from '../ui/PostCard.astro';
-import { getFeaturedPosts } from '../../data/posts';
+import { getPosts, selectByPlatform } from '../../data/posts';
 
-const visiblePosts = getFeaturedPosts(3);
+const posts = getPosts();
 
-// TODO: update this URL to your blog once you have real posts ready
-const blogUrl = 'http://blog.okeefesarah.com';
+const rows = [
+  {
+    label: 'Engineering',
+    href: 'https://sarahmorrisokeefe.medium.com',
+    posts: selectByPlatform(posts, 'medium', 3),
+  },
+  {
+    label: 'Chart Position',
+    href: 'https://chartposition.substack.com',
+    posts: selectByPlatform(posts, 'substack', 3),
+  },
+];
 ---
 
 <section id="writing" class="bg-cream dark:bg-ink-dark py-20 md:py-28 px-6">
   <div class="max-w-5xl mx-auto">
-    <div class="flex flex-col sm:flex-row sm:items-end justify-between gap-6 mb-12">
-      <SectionHeading
-        title="Writing"
-        subtitle="Thoughts on code, music, and whatever I'm obsessed with this month."
-        class="mb-0"
-      />
-      <a
-        href={blogUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="shrink-0 text-sm font-medium text-sage dark:text-sage-light hover:text-ink-dark dark:hover:text-cream transition-colors duration-200 whitespace-nowrap flex items-center gap-1.5"
-      >
-        All posts
-        <svg
-          class="w-3.5 h-3.5"
-          viewBox="0 0 14 14"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          aria-hidden="true"
-        >
-          <path d="M2 7h10M8 3l4 4-4 4" stroke-linecap="round" stroke-linejoin="round"
-          ></path>
-        </svg>
-      </a>
-    </div>
+    <SectionHeading
+      title="Writing"
+      subtitle="Thoughts on code, music, and whatever I'm obsessed with this month."
+    />
 
-    {
-      visiblePosts.length > 0 ? (
-        <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-5 fade-up-stagger">
-          {visiblePosts.map((post) => (
-            <PostCard post={post} />
-          ))}
-        </div>
-      ) : (
-        <div class="text-center py-16">
-          <p class="text-ink/40 dark:text-cream/30 text-sm">
-            Posts coming soon. In the meantime,{' '}
-            <a
-              href={blogUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-sage dark:text-sage-light hover:underline"
-            >
-              visit the blog →
-            </a>
-          </p>
-        </div>
-      )
-    }
+    <div class="space-y-12">
+      {
+        rows.map((row) => (
+          <div>
+            <div class="flex items-end justify-between gap-6 mb-5">
+              <h3 class="font-serif text-xl text-ink-dark dark:text-cream">
+                {row.label}
+              </h3>
+              <a
+                href={row.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="shrink-0 text-sm font-medium text-sage dark:text-sage-light hover:text-ink-dark dark:hover:text-cream transition-colors duration-200 whitespace-nowrap flex items-center gap-1.5"
+              >
+                All posts
+                <svg
+                  class="w-3.5 h-3.5"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M2 7h10M8 3l4 4-4 4"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </a>
+            </div>
+
+            {row.posts.length > 0 ? (
+              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 fade-up-stagger">
+                {row.posts.map((post, i) => (
+                  <PostCard
+                    post={post}
+                    class={i === 2 ? 'hidden lg:flex' : undefined}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p class="text-ink/40 dark:text-cream/30 text-sm">
+                Posts coming soon.
+              </p>
+            )}
+          </div>
+        ))
+      }
+    </div>
   </div>
 </section>

--- a/src/components/ui/PostCard.astro
+++ b/src/components/ui/PostCard.astro
@@ -3,35 +3,35 @@ import type { Post } from '../../data/posts';
 
 interface Props {
   post: Post;
+  class?: string;
 }
 
-const { post } = Astro.props;
+const { post, class: className = '' } = Astro.props;
 
 const formattedDate = new Date(post.pubDate).toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
 });
-
-const platformLabel = post.platform.charAt(0).toUpperCase() + post.platform.slice(1);
 ---
 
 <article
-  class="group p-6 rounded-xl border border-cream-alt dark:border-ink/30 bg-cream dark:bg-ink-dark hover:shadow-md dark:hover:shadow-ink-darker/50 hover:-translate-y-0.5 transition-all duration-300 flex flex-col"
+  class:list={[
+    'group p-6 rounded-xl border border-cream-alt dark:border-ink/30 bg-cream dark:bg-ink-dark hover:shadow-md dark:hover:shadow-ink-darker/50 hover:-translate-y-0.5 transition-all duration-300 flex flex-col',
+    className,
+  ]}
 >
   <div
     class="flex items-center gap-2 text-xs text-ink/40 dark:text-cream/30 mb-3 font-medium tracking-wide uppercase"
   >
     <time datetime={post.pubDate}>{formattedDate}</time>
-    <span aria-hidden="true">·</span>
-    <span>{platformLabel}</span>
   </div>
 
-  <h3
+  <h4
     class="font-serif text-lg text-ink-dark dark:text-cream group-hover:text-sage dark:group-hover:text-sage-light transition-colors duration-200 mb-3 leading-snug"
   >
     {post.title}
-  </h3>
+  </h4>
 
   <p class="text-sm leading-relaxed text-ink dark:text-cream/60 mb-5 flex-1">
     {post.description}
@@ -52,7 +52,10 @@ const platformLabel = post.platform.charAt(0).toUpperCase() + post.platform.slic
       stroke-width="1.5"
       aria-hidden="true"
     >
-      <path d="M2 6h8M7 3l3 3-3 3" stroke-linecap="round" stroke-linejoin="round"></path>
+      <path
+        d="M2 6h8M7 3l3 3-3 3"
+        stroke-linecap="round"
+        stroke-linejoin="round"></path>
     </svg>
   </a>
 </article>

--- a/src/data/__tests__/posts.test.ts
+++ b/src/data/__tests__/posts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pickFeatured, type Post } from '../posts';
+import { selectByPlatform, type Post } from '../posts';
 
 function post(
   id: string,
@@ -15,68 +15,46 @@ function post(
   };
 }
 
-describe('pickFeatured', () => {
-  it('returns all posts when there are fewer than count', () => {
-    const posts = [
-      post('a', 'medium', '2026-05-03'),
-      post('b', 'substack', '2026-05-02'),
-    ];
-    expect(pickFeatured(posts, 3)).toHaveLength(2);
+const posts = [
+  post('s1', 'substack', '2026-05-28'),
+  post('m1', 'medium', '2026-05-22'),
+  post('s2', 'substack', '2026-05-20'),
+  post('m2', 'medium', '2026-05-18'),
+  post('m3', 'medium', '2026-05-15'),
+  post('m4', 'medium', '2026-05-10'),
+];
+
+describe('selectByPlatform', () => {
+  it('returns only posts of the requested platform', () => {
+    expect(
+      selectByPlatform(posts, 'substack', 10).every(
+        (p) => p.platform === 'substack',
+      ),
+    ).toBe(true);
   });
 
-  it('keeps pure recency when the top already mixes platforms', () => {
-    const posts = [
-      post('s1', 'substack', '2026-05-10'),
-      post('m1', 'medium', '2026-05-09'),
-      post('s2', 'substack', '2026-05-08'),
-      post('m2', 'medium', '2026-05-07'),
-    ];
-    expect(pickFeatured(posts, 3).map((p) => p.title)).toEqual([
-      's1',
-      'm1',
-      's2',
-    ]);
+  it('caps the result at the given limit', () => {
+    expect(selectByPlatform(posts, 'medium', 3)).toHaveLength(3);
   });
 
-  it('forces a medium post in when the top three are all substack', () => {
-    const posts = [
-      post('s1', 'substack', '2026-05-28'),
-      post('s2', 'substack', '2026-05-25'),
-      post('s3', 'substack', '2026-05-24'),
-      post('m1', 'medium', '2026-05-22'),
-      post('m2', 'medium', '2026-05-20'),
-    ];
-    const result = pickFeatured(posts, 3);
-    expect(result).toHaveLength(3);
-    expect(result.some((p) => p.platform === 'medium')).toBe(true);
-    expect(result.some((p) => p.platform === 'substack')).toBe(true);
-    // most recent medium added, oldest substack evicted, result sorted desc
-    expect(result.map((p) => p.title)).toEqual(['s1', 's2', 'm1']);
-  });
-
-  it('forces a substack post in when the top three are all medium', () => {
-    const posts = [
-      post('m1', 'medium', '2026-05-28'),
-      post('m2', 'medium', '2026-05-25'),
-      post('m3', 'medium', '2026-05-24'),
-      post('s1', 'substack', '2026-05-22'),
-    ];
-    const result = pickFeatured(posts, 3);
-    expect(result.some((p) => p.platform === 'substack')).toBe(true);
-    expect(result.map((p) => p.title)).toEqual(['m1', 'm2', 's1']);
-  });
-
-  it('leaves a single-platform set unchanged (only fills what exists)', () => {
-    const posts = [
-      post('m1', 'medium', '2026-05-10'),
-      post('m2', 'medium', '2026-05-09'),
-      post('m3', 'medium', '2026-05-08'),
-      post('m4', 'medium', '2026-05-07'),
-    ];
-    expect(pickFeatured(posts, 3).map((p) => p.title)).toEqual([
+  it('preserves the input (newest-first) order', () => {
+    expect(selectByPlatform(posts, 'medium', 3).map((p) => p.title)).toEqual([
       'm1',
       'm2',
       'm3',
     ]);
+  });
+
+  it('returns everything available when fewer than the limit exist', () => {
+    expect(selectByPlatform(posts, 'substack', 5).map((p) => p.title)).toEqual([
+      's1',
+      's2',
+    ]);
+  });
+
+  it('returns an empty array when no posts match', () => {
+    expect(
+      selectByPlatform([post('m1', 'medium', '2026-05-01')], 'substack', 3),
+    ).toEqual([]);
   });
 });

--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -24,32 +24,13 @@ export function getPosts(): Post[] {
 }
 
 /**
- * Select `count` teasers favouring recency, but guarantee every platform that
- * exists in the data is represented (so the dev/writing mix never collapses to
- * a single platform). Assumes `posts` is already sorted newest-first.
+ * The most recent `limit` posts from a single platform, preserving the
+ * newest-first order of the input.
  */
-export function pickFeatured(posts: Post[], count: number): Post[] {
-  if (posts.length <= count) return posts;
-  const result = posts.slice(0, count);
-  for (const platform of new Set(posts.map((p) => p.platform))) {
-    if (result.some((p) => p.platform === platform)) continue;
-    const candidate = posts.find((p) => p.platform === platform);
-    if (!candidate) continue;
-    // Evict the lowest-priority item whose platform is over-represented.
-    for (let i = result.length - 1; i >= 0; i--) {
-      const overrepresented =
-        result.filter((p) => p.platform === result[i].platform).length > 1;
-      if (overrepresented) {
-        result[i] = candidate;
-        break;
-      }
-    }
-  }
-  return [...result].sort((a, b) =>
-    a.pubDate < b.pubDate ? 1 : a.pubDate > b.pubDate ? -1 : 0,
-  );
-}
-
-export function getFeaturedPosts(count = 3): Post[] {
-  return pickFeatured(getPosts(), count);
+export function selectByPlatform(
+  posts: Post[],
+  platform: Post['platform'],
+  limit: number,
+): Post[] {
+  return posts.filter((post) => post.platform === platform).slice(0, limit);
 }


### PR DESCRIPTION
## Summary
Replaces the single mixed row of teasers with **two labeled rows**, each sourced from one platform and linking to it:
- **Engineering** → Medium posts, "All posts" → `https://sarahmorrisokeefe.medium.com`
- **Chart Position** → Substack posts, "All posts" → `https://chartposition.substack.com`

Layout: **3 cards per row on desktop, 2 on mobile** (the 3rd card is `hidden lg:flex`). Builds on the RSS auto-population from #47 — no data-pipeline changes.

## Changes
- Swapped the `getFeaturedPosts`/`pickFeatured` mix selector for a simple, pure `selectByPlatform(posts, platform, limit)` (the mix logic is obsolete now that rows are split by platform).
- `Writing.astro` restructured into two rows, each with an `h3` header + its own "All posts" link; dropped the unused `blogUrl` placeholder.
- `PostCard` gains an optional `class` prop (used to hide the 3rd card on mobile) and card titles moved `h3` → `h4` to sit correctly under the new `h3` row headings (`h2` → `h3` → `h4`).
- Each "All posts" link gets an `aria-label` ("All posts on Engineering" / "…on Chart Position") so the two same-text links have distinct accessible names (WCAG 2.4.6 / 4.1.2).

## Judgment calls (easy to revert)
- **Removed the per-card platform label** ("· Medium" / "· Substack" under the date) — redundant now that each row is labeled, and it avoided showing "Substack" under a "Chart Position" header.
- Medium "All posts" points at the **profile**; can be repointed if you prefer something more specific.

## Test plan
- [x] `npx vitest run` — 49 tests green (new `selectByPlatform` tests replace the old `pickFeatured` ones)
- [x] `npm run build` — clean; rendered HTML verified (2 rows, correct headers/links, 6 cards, 3rd hidden below `lg`, heading hierarchy h2→h3→h4)
- [ ] **Visual check (not yet done):** eyeball spacing between the two rows, the 2-up mobile / 3-up desktop feel, dark mode, and card alignment in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)