### PR TITLE
Add Avalora project; make teaser titles clickable

### DIFF
--- a/src/components/ui/PostCard.astro
+++ b/src/components/ui/PostCard.astro
@@ -30,7 +30,14 @@ const formattedDate = new Date(post.pubDate).toLocaleDateString('en-US', {
   <h4
     class="font-serif text-lg text-ink-dark dark:text-cream group-hover:text-sage dark:group-hover:text-sage-light transition-colors duration-200 mb-3 leading-snug"
   >
-    {post.title}
+    <a
+      href={post.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="hover:underline underline-offset-2 focus-visible:underline"
+    >
+      {post.title}
+    </a>
   </h4>
 
   <p class="text-sm leading-relaxed text-ink dark:text-cream/60 mb-5 flex-1">

--- a/src/components/ui/ProjectCard.astro
+++ b/src/components/ui/ProjectCard.astro
@@ -52,9 +52,20 @@ const { project, featured = false } = Astro.props;
           rel="noopener noreferrer"
           class="inline-flex items-center gap-1 text-xs font-medium text-sage dark:text-sage-light hover:text-ink-dark dark:hover:text-cream border border-sage/25 dark:border-sage-light/20 hover:border-ink-dark/30 dark:hover:border-cream/30 px-3 py-1.5 rounded-full transition-all duration-200"
         >
-          GitHub
-          <svg class="w-3 h-3" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-            <path d="M2 10L10 2M10 2H4M10 2v6" stroke-linecap="round" stroke-linejoin="round"/>
+          {project.githubLabel ?? 'GitHub'}
+          <svg
+            class="w-3 h-3"
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            aria-hidden="true"
+          >
+            <path
+              d="M2 10L10 2M10 2H4M10 2v6"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
           </svg>
         </a>
       )
@@ -68,8 +79,19 @@ const { project, featured = false } = Astro.props;
           class="inline-flex items-center gap-1 text-xs font-medium text-sage dark:text-sage-light hover:text-ink-dark dark:hover:text-cream border border-sage/25 dark:border-sage-light/20 hover:border-ink-dark/30 dark:hover:border-cream/30 px-3 py-1.5 rounded-full transition-all duration-200"
         >
           Live demo
-          <svg class="w-3 h-3" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-            <path d="M2 10L10 2M10 2H4M10 2v6" stroke-linecap="round" stroke-linejoin="round"/>
+          <svg
+            class="w-3 h-3"
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            aria-hidden="true"
+          >
+            <path
+              d="M2 10L10 2M10 2H4M10 2v6"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
           </svg>
         </a>
       )
@@ -83,8 +105,19 @@ const { project, featured = false } = Astro.props;
           class="inline-flex items-center gap-1 text-xs font-medium text-sage dark:text-sage-light hover:text-ink-dark dark:hover:text-cream border border-sage/25 dark:border-sage-light/20 hover:border-ink-dark/30 dark:hover:border-cream/30 px-3 py-1.5 rounded-full transition-all duration-200"
         >
           CodePen
-          <svg class="w-3 h-3" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-            <path d="M2 10L10 2M10 2H4M10 2v6" stroke-linecap="round" stroke-linejoin="round"/>
+          <svg
+            class="w-3 h-3"
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            aria-hidden="true"
+          >
+            <path
+              d="M2 10L10 2M10 2H4M10 2v6"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
           </svg>
         </a>
       )

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -6,6 +6,8 @@ export interface Project {
   // 2-3 sentences — conversational, not a job description
   description: string;
   githubUrl?: string;
+  // Optional label for the GitHub link (defaults to "GitHub")
+  githubLabel?: string;
   liveUrl?: string;
   codepenUrl?: string;
   // featured: true = shown in the large top card slot
@@ -27,6 +29,19 @@ export const projects: Project[] = [
     technologies: ['React', 'TypeScript', 'Tailwind CSS'],
     year: '2026',
     category: 'project',
+  },
+  {
+    id: 'avalora',
+    name: 'Avalora',
+    description:
+      'A live band website built on a reusable Next.js + Sanity platform I designed so any band can run their own site — shows, releases, press — and edit everything themselves through an embedded CMS, no code required. Avalora is the first client on it: the template repo is open source, while each band’s own site and content stay private.',
+    githubUrl: 'https://github.com/sarahmorrisokeefe/band-site-template',
+    githubLabel: 'Template on GitHub',
+    liveUrl: 'https://www.avaloraband.com',
+    featured: false,
+    technologies: ['Next.js', 'Sanity', 'TypeScript', 'Tailwind CSS'],
+    year: '2026',
+    category: 'work',
   },
   {
     id: 'formula-one-data-vis',


### PR DESCRIPTION
Two small front-page changes (bundled per request).

## 1. Avalora band site → Projects
Adds the **Avalora** client site as a `work` project (leads the project grid, after the featured Cadence card).
- **Live demo** → https://www.avaloraband.com
- **Template on GitHub** → the public `band-site-template` repo (the band's own repo is private, so the link points at the open-source template, with a custom label).
- New optional `githubLabel?: string` on the `Project` type; `ProjectCard` renders `{project.githubLabel ?? 'GitHub'}` so other projects keep the default "GitHub" label.
- Tech tags: Next.js · Sanity · TypeScript · Tailwind CSS.

## 2. Clickable teaser titles (Writing section)
- Wrap each post title in a link to the article (opens in a new tab, same as "Read more", which stays). Hover/focus underline as the affordance; the anchor inherits the heading color so the resting look is unchanged.

> Note: this branch merges in the now-merged #48 (Writing per-platform rows), so the title change is made against the current `<h4>` card markup — no conflict.

## Test plan
- [x] `npx vitest run` — 49 tests green
- [x] `npm run build` — clean; verified: Avalora card (correct labels/links, others still "GitHub"); all 6 teaser titles wrap an article link and "Read more" is retained
- [ ] **Visual check (not yet done):** eyeball the Avalora card and the clickable titles (hover affordance, dark mode) in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)