### PR TITLE
fix: send User-Agent when fetching feeds so Substack posts update

### DIFF
--- a/src/data/__tests__/feed-parser.test.ts
+++ b/src/data/__tests__/feed-parser.test.ts
@@ -261,6 +261,23 @@ describe('buildPosts', () => {
     expect(posts.some((p) => p.platform === 'substack')).toBe(true);
   });
 
+  it('sends a User-Agent header so Substack/Cloudflare does not reject the request', async () => {
+    const seen: Array<RequestInit | undefined> = [];
+    const fetchImpl = async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      seen.push(init);
+      return String(url).includes('medium') ? ok(MEDIUM_RSS) : ok(SUBSTACK_RSS);
+    };
+    await buildPosts(SOURCES, EXISTING, fetchImpl as typeof fetch);
+    expect(seen).toHaveLength(2);
+    for (const init of seen) {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      expect(headers['User-Agent']).toBeTruthy();
+    }
+  });
+
   it('returns the existing set unchanged when both feeds fail', async () => {
     const fetchImpl = async () => fail();
     const posts = await buildPosts(

--- a/src/data/feed-parser.ts
+++ b/src/data/feed-parser.ts
@@ -127,6 +127,16 @@ export function mergeAndSort(...lists: Post[][]): Post[] {
   });
 }
 
+// Substack sits behind Cloudflare, which rejects the default Node fetch
+// User-Agent (the request fails outright). Sending a real UA — and an RSS
+// Accept header — keeps the feed reachable. Medium is unaffected but gets the
+// same headers for consistency.
+const FEED_HEADERS = {
+  'User-Agent':
+    'Mozilla/5.0 (compatible; okeefesarah-feed-fetcher/1.0; +https://www.okeefesarah.com)',
+  Accept: 'application/rss+xml, application/xml;q=0.9, */*;q=0.8',
+};
+
 export async function buildPosts(
   sources: FeedSource[],
   existing: Post[],
@@ -134,7 +144,7 @@ export async function buildPosts(
 ): Promise<Post[]> {
   const results = await Promise.allSettled(
     sources.map(async (source) => {
-      const res = await fetchImpl(source.url);
+      const res = await fetchImpl(source.url, { headers: FEED_HEADERS });
       if (!res.ok)
         throw new Error(`${source.platform} feed responded ${res.status}`);
       return parseFeed(await res.text(), source.platform);

--- a/src/data/posts.generated.json
+++ b/src/data/posts.generated.json
@@ -7,6 +7,20 @@
     "platform": "medium"
   },
   {
+    "title": "Barcelona: The New Moon Didn’t Care About Your Two-Stop Plan",
+    "description": "ROUND 9 RECAP: SPANISH GRAND PRIX · Circuit de Barcelona-Catalunya · June 14, 2026",
+    "url": "https://chartposition.substack.com/p/barcelona-the-new-moon-didnt-care",
+    "pubDate": "2026-06-15",
+    "platform": "substack"
+  },
+  {
+    "title": "The Out Lap: June 15–21",
+    "description": "A New Moon just wiped the slate clean, and the solstice is coming to make it official.",
+    "url": "https://chartposition.substack.com/p/the-out-lap-june-1521",
+    "pubDate": "2026-06-15",
+    "platform": "substack"
+  },
+  {
     "title": "D3 vs Recharts: I Used Both in One Project and Drew a Clear Line",
     "description": "Eight pages of Recharts, three custom D3 components, and one heatmap that needed neither.",
     "url": "https://medium.com/womenintechnology/d3-vs-recharts-i-used-both-in-one-project-and-drew-a-clear-line-47173433f277",
@@ -14,11 +28,46 @@
     "platform": "medium"
   },
   {
+    "title": "Sector by Sector: Astrological Weather at Barcelona",
+    "description": "Barcelona-Catalunya Grand Prix · Round 9 · June 12–14, 2026",
+    "url": "https://chartposition.substack.com/p/sector-by-sector-astrological-weather-027",
+    "pubDate": "2026-06-11",
+    "platform": "substack"
+  },
+  {
+    "title": "Monaco: Neptune's Track, Virgo's Driver",
+    "description": "ROUND 6 RECAP: MONACO GRAND PRIX · Circuit de Monaco · June 7, 2026",
+    "url": "https://chartposition.substack.com/p/monaco-neptunes-track-virgos-driver",
+    "pubDate": "2026-06-08",
+    "platform": "substack"
+  },
+  {
+    "title": "The Out Lap: June 8-14",
+    "description": "Last Quarter Moon in Pisces, a Venus ingress into Leo, and a Gemini New Moon walk into a bar.",
+    "url": "https://chartposition.substack.com/p/the-out-lap-june-8-14",
+    "pubDate": "2026-06-08",
+    "platform": "substack"
+  },
+  {
+    "title": "Sector by Sector: Astrological Weather at Monaco",
+    "description": "Monte Carlo · Round 6 · June 5–7, 2026",
+    "url": "https://chartposition.substack.com/p/sector-by-sector-astrological-weather-6b1",
+    "pubDate": "2026-06-04",
+    "platform": "substack"
+  },
+  {
     "title": "One Resend Integration, Two Email Flows: Transactional and Marketing Email in a Next.js Template",
     "description": "How a pluggable delivery layer kept the email architecture clean, and what the real implementation revealed about the decisions worth…",
     "url": "https://medium.com/womenintechnology/one-resend-integration-two-email-flows-transactional-and-marketing-email-in-a-next-js-template-8158c472c558",
     "pubDate": "2026-06-01",
     "platform": "medium"
+  },
+  {
+    "title": "The Out Lap: June 1-7",
+    "description": "Mercury shifts into Cancer and the week gets quieter in all the right ways.",
+    "url": "https://chartposition.substack.com/p/the-out-lap-june-1-7",
+    "pubDate": "2026-06-01",
+    "platform": "substack"
   },
   {
     "title": "What Canada Reveals Every Time: The Circuit That Breaks Hearts on Purpose",
@@ -140,25 +189,11 @@
     "platform": "medium"
   },
   {
-    "title": "The Out Lap: April 20–26",
-    "description": "The Sun is in Taurus, but Aries isn't finished. And Uranus is about to arrive for good.",
-    "url": "https://chartposition.substack.com/p/the-out-lap-april-2026",
-    "pubDate": "2026-04-20",
-    "platform": "substack"
-  },
-  {
     "title": "Claude Is Making Our Jobs Lonelier. Here’s What I’m Doing About It.",
     "description": "On the quiet cost of replacing collaboration with AI, and what I did about it.",
     "url": "https://medium.com/womenintechnology/claude-is-making-our-jobs-lonelier-heres-what-i-m-doing-about-it-c4e5adec7118",
     "pubDate": "2026-04-17",
     "platform": "medium"
-  },
-  {
-    "title": "F1's New Era Is Already Under Review",
-    "description": "On the timing of F1's biggest regulation overhaul, a 50G crash at Suzuka, and a planet that tends to see these things coming.",
-    "url": "https://chartposition.substack.com/p/f1s-new-era-is-already-under-review",
-    "pubDate": "2026-04-16",
-    "platform": "substack"
   },
   {
     "title": "Your Existing Web App Is Closer to a Mobile App Than You Think",
@@ -168,45 +203,10 @@
     "platform": "medium"
   },
   {
-    "title": "The Out Lap: April 13–19",
-    "description": "A once-in-a-lifetime Aries overload: seven celestial bodies lead us into the most charged New Moon of the year.",
-    "url": "https://chartposition.substack.com/p/the-out-lap-week-of-april-1319",
-    "pubDate": "2026-04-13",
-    "platform": "substack"
-  },
-  {
     "title": "What I Thought Having a Baby Would Do to My Career (And What Actually Happened)",
     "description": "The gold star didn’t disappear. It just stopped being the point.",
     "url": "https://medium.com/womenintechnology/what-i-thought-having-a-baby-would-do-to-my-career-and-what-actually-happened-53192100c0ad",
     "pubDate": "2026-04-11",
     "platform": "medium"
-  },
-  {
-    "title": "The Long Game: Lewis Hamilton, Saturn, and the Ferrari Chapter",
-    "description": "On the move to Ferrari, and why a Capricorn ruled by Saturn doesn't get shortcuts - he gets longevity.",
-    "url": "https://chartposition.substack.com/p/the-long-game-lewis-hamilton-saturn",
-    "pubDate": "2026-04-09",
-    "platform": "substack"
-  },
-  {
-    "title": "The Out Lap: April 6–12",
-    "description": "Mars is coming home and it's about to get loud",
-    "url": "https://chartposition.substack.com/p/the-out-lap-april-612",
-    "pubDate": "2026-04-06",
-    "platform": "substack"
-  },
-  {
-    "title": "Two Stelliums, One Seat",
-    "description": "Three planets in Virgo. Three in Leo. And a timely nodal return. A birth chart deep dive into Formula One's youngest championship leader.",
-    "url": "https://chartposition.substack.com/p/two-stelliums-one-seat",
-    "pubDate": "2026-04-02",
-    "platform": "substack"
-  },
-  {
-    "title": "The Safety Car Was Always Coming",
-    "description": "ROUND 3 RECAP: JAPANESE GRAND PRIX · Suzuka Circuit · March 29, 2026",
-    "url": "https://chartposition.substack.com/p/the-safety-car-was-always-coming",
-    "pubDate": "2026-03-30",
-    "platform": "substack"
   }
 ]


### PR DESCRIPTION
## Problem

Substack articles stopped updating in the Writing section. The generated post data (`posts.generated.json`) had been frozen at **May 29** even though the daily **Refresh post teasers** Action reported success every day.

## Root cause

`buildPosts` fetched each feed with **no `User-Agent` header**. Substack sits behind Cloudflare, which rejects the default Node `fetch` UA outright, so the fetch threw. `buildPosts` then fell back to its "keeping previous slice" path, leaving Substack frozen at the last good copy. Because the output never changed, the Action's `git diff` check found nothing to commit — so it stayed green while silently doing nothing. Medium was unaffected (it doesn't block the default UA).

Confirmed against the real GitHub Actions log:
```
[feed-parser] substack feed unavailable; keeping previous slice
... No feed changes.
```

## Fix

- Send a real `User-Agent` (and an RSS `Accept`) header on the feed fetches in `feed-parser.ts`. Verified the UA returns HTTP 200 with 20 items from Substack.
- Add a regression test asserting the header is sent on every fetch.
- Regenerate `posts.generated.json` so the next deploy shows fresh Substack posts immediately (current through June 15) rather than waiting for the cron.

## Verification

- `npx vitest run` → 50/50 pass
- `npm run posts:refresh` now pulls Substack posts current to June 15 with no "unavailable" warning

## Follow-up to watch

The Action's commit-back hasn't pushed since May 29 (no diffs), so it's never exercised the commit-back → Vercel deploy path. Once the next cron produces a real diff, worth confirming that push triggers a Vercel deploy (add a Deploy Hook step if not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)