### PR TITLE
fix: back-to-site nav and mobile layout on /web-dev

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -23,8 +23,24 @@ const navLinks: { href: string; label: string; external?: boolean }[] = [
     <!-- Logo / Name -->
     <a
       href="/"
-      class="font-serif text-lg text-ink-dark dark:text-cream hover:text-sage dark:hover:text-sage-light transition-colors duration-200"
+      class="inline-flex items-center gap-1.5 font-serif text-lg text-ink-dark dark:text-cream hover:text-sage dark:hover:text-sage-light transition-colors duration-200"
     >
+      {
+        simple && (
+          <svg
+            class="w-4 h-4 shrink-0"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M19 12H5M11 18l-6-6 6-6" />
+          </svg>
+        )
+      }
       Sarah O'Keefe
     </a>
 

--- a/src/components/sections/WebDev.astro
+++ b/src/components/sections/WebDev.astro
@@ -271,7 +271,7 @@ const contactEmail = "hello@okeefesarah.com";
   .intro p strong { color: var(--teal); font-weight: 700; }
 
   /* SECTION HEAD */
-  .section-head { padding: 64px 28px 8px; }
+  .section-head { padding: 64px 0 8px; }
   .section-head .eyebrow { margin-bottom: 14px; }
   .section-head h2 {
     font-size: clamp(1.7rem, 3.5vw, 2.4rem);
@@ -413,7 +413,7 @@ const contactEmail = "hello@okeefesarah.com";
   /* PROCESS */
   .process { padding-bottom: 24px; }
   .steps {
-    padding: 36px 28px 8px;
+    padding: 36px 0 8px;
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: 28px;
@@ -486,6 +486,13 @@ const contactEmail = "hello@okeefesarah.com";
   @media (max-width: 720px) {
     .intro { grid-template-columns: 1fr; gap: 24px; }
     .steps { grid-template-columns: 1fr 1fr; gap: 32px 24px; }
+  }
+  @media (max-width: 520px) {
+    .wrap { padding: 0 20px; }
+    .hero { padding: 72px 0 48px; }
+    .steps { grid-template-columns: 1fr; gap: 28px; }
+    .care { padding: 48px 0; }
+    .cta { padding: 56px 0; }
   }
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Add a back arrow to the header wordmark in `simple` mode (used only on `/web-dev`) so there's an unmistakable way back to the main site — the wordmark already linked home but read as a brand mark, not a nav affordance, and the fixed header keeps it visible at any scroll depth.
- Fix a doubled horizontal-padding bug in the "How It Works" section (`.section-head` and `.steps` were both nested inside `.wrap` and re-declared the same 28px padding), which squeezed the step grid into ~120px columns on small phones.
- Add a 520px breakpoint that stacks the step grid to one column and tightens hero/care/CTA vertical padding and gutters, which were sized for desktop and felt bloated on mobile.

## Test plan
- [x] `npm run build` completes cleanly
- [x] Verified compiled output: back arrow appears only on `/web-dev`, not on `/`
- [x] Verified compiled CSS: `.section-head`/`.steps` padding fix and new `520px` breakpoint landed as expected
- [ ] Eyeball `/web-dev` on an actual phone / mobile emulator to confirm it feels right

🤖 Generated with [Claude Code](https://claude.com/claude-code)