### PR TITLE
Add Google Analytics 4 tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ dist-ssr
 # Astro auto-generated types/content cache
 .astro
 
+# Environment variables
+.env
+.env.*
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/components/layout/BaseLayout.astro
+++ b/src/components/layout/BaseLayout.astro
@@ -12,6 +12,9 @@ const {
   title = "Sarah O'Keefe — Front-End Engineer",
   description = 'Front-end software engineer based in Charlotte, NC. Building things with React and TypeScript at iHeartRadio.',
 } = Astro.props;
+
+const gaId = import.meta.env.PUBLIC_GA_ID;
+const enableAnalytics = import.meta.env.PROD && gaId;
 ---
 
 <!doctype html>
@@ -62,6 +65,27 @@ const {
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
+
+    <!-- Google Analytics 4 (production only, gated by import.meta.env.PROD) -->
+    {
+      enableAnalytics && (
+        <>
+          <script
+            is:inline
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+          />
+          <script is:inline define:vars={{ gaId }}>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+              dataLayer.push(arguments);
+            }
+            gtag('js', new Date());
+            gtag('config', gaId);
+          </script>
+        </>
+      )
+    }
   </head>
   <body>
     <slot />


### PR DESCRIPTION
## Summary
- Adds GA4 (`gtag.js`) site-wide via the shared `BaseLayout.astro` head, keyed off `PUBLIC_GA_ID`
- Gated to production only (`import.meta.env.PROD`) so local dev traffic isn't tracked
- No View Transitions in use on this site, so no soft-navigation listener is needed — every nav is already a full page load
- Vercel Web Analytics (`<Analytics />`) is left untouched; both run side by side

## Setup required before merge
Add `PUBLIC_GA_ID = G-5MR756KT9M` to the Vercel project's Environment Variables (Production).

## Test plan
- [x] `npm run build` succeeds
- [x] Confirmed `dist/index.html` contains the gtag.js script tag with the measurement ID after a production build
- [ ] After deploy, confirm GA4 Realtime report shows an active user on visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)