### PR TITLE
Fix posts-refresh Action blocked by required CodeQL check

### DIFF
--- a/.github/workflows/refresh-posts.yml
+++ b/.github/workflows/refresh-posts.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   refresh:
@@ -23,14 +24,27 @@ jobs:
 
       - run: npm run posts:refresh
 
-      - name: Commit refreshed data if it changed
+      - name: Open PR with refreshed data if it changed
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if git diff --quiet src/data/posts.generated.json; then
             echo "No feed changes."
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add src/data/posts.generated.json
-            git commit -m "chore: refresh post teasers from feeds"
-            git push
+            exit 0
           fi
+
+          branch="posts-refresh/$(date +%Y%m%d%H%M%S)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add src/data/posts.generated.json
+          git commit -m "chore: refresh post teasers from feeds"
+          git push origin "$branch"
+
+          gh pr create \
+            --title "chore: refresh post teasers from feeds" \
+            --body "Automated daily refresh of post teasers from Medium/Substack feeds." \
+            --base master \
+            --head "$branch"
+
+          gh pr merge "$branch" --auto --squash


### PR DESCRIPTION
## Summary
- The daily "Refresh post teasers" Action pushed straight to `master` via `git push`, which now fails: branch protection requires the `Analyze (javascript)` CodeQL check, and a direct push can never satisfy a check that only runs after the commit exists (chicken/egg).
- Switch the workflow to push its commit to a throwaway branch, open a PR, and enable auto-merge — CodeQL already runs on PRs targeting `master` (see `codeql-analysis.yml`), so the merge now waits for a real pass instead of being rejected outright.
- Enabled "Allow auto-merge" on the repo (was off) since the fix depends on it.

## Test plan
- [ ] Merge this PR
- [ ] Trigger the workflow manually (`workflow_dispatch`) and confirm it opens a PR against `master`, CodeQL runs on it, and it auto-merges once green
- [ ] Confirm the next scheduled 11:00 UTC run behaves the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)